### PR TITLE
Debug github workflow build and deploy errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "notes",
+  "name": "workspace",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
Update `package-lock.json` name to `workspace` as a part of resolving GitHub workflow deployment issues.

The primary issue causing the GitHub Pages deployment to fail was the missing `base` path in the VitePress configuration (`.vitepress/config.mjs`). The `base: '/notes/'` setting was added to ensure correct asset loading for the `notes` repository. This change to `package-lock.json` was generated during the dependency update and build verification steps of the fix.

---
<a href="https://cursor.com/background-agent?bcId=bc-25e26234-d71b-4d2e-8454-b7c64cf4f591">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-25e26234-d71b-4d2e-8454-b7c64cf4f591">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

