### PR TITLE
docs(security): add LLM Agent layered defense architecture

### DIFF
--- a/.vitepress/config.mjs
+++ b/.vitepress/config.mjs
@@ -458,6 +458,13 @@ export default defineConfig({
               ]
             },
             {
+              text: 'LLM Agent 防御',
+              collapsed: true,
+              items: [
+                { text: '分层防御方案（IAM + 规则 + Content Guard + NSFA + 沙箱）', link: '/security/llm_agent_defense/layered_defense' }
+              ]
+            },
+            {
               text: 'Linux 内核安全',
               collapsed: true,
               items: [

--- a/security/llm_agent_defense/layered_defense.md
+++ b/security/llm_agent_defense/layered_defense.md
@@ -1,0 +1,1081 @@
+---
+title: LLM Agent 分层防御方案
+---
+
+# LLM Agent 分层防御方案
+
+> 以 **SingGuard / SingGuard-NSFA + Agent IAM + 规则层** 为核心，构建面向车端、云端、移动端的纵深防御体系。
+
+## 1. 设计目标
+
+| 目标 | 说明 |
+| ---- | ---- |
+| **可解释** | 每一次拦截都附带原因（规则 / 模型 / 风险类别） |
+| **低延迟** | 同步链路 P95 ≤ 200 ms |
+| **低耦合** | 每个组件可独立扩缩容与升级 |
+| **可审计** | 关键决策进入不可变日志 |
+| **可降级** | 模型失效时自动回退到规则层 |
+
+## 2. 整体架构
+
+```mermaid
+flowchart TD
+    U[用户请求] --> IAM{Agent IAM<br/>身份 / Scope / 委托}
+    IAM -- 401/403 --> A1[拒绝 + 审计]
+    IAM -- 通过 --> RL[规则匹配层<br/>AC + Regex + OPA]
+    RL -- 命中黑名单 --> A2[拦截 + 审计]
+    RL -- 未命中 --> CG[Guard-Agent-1<br/>Content Guard]
+    CG -- 内容违规 --> A3[拦截 + 审计]
+    CG -- 不确定 / 高风险 --> RG[Guard-Agent-2<br/>NSFA Risk Guard]
+    RG -- 工具滥用 / 注入 --> A4[拦截 + 审计]
+    RG -- 通过 --> SC[工具沙箱]
+    SC --> T[工具执行]
+    T --> OG[Guard-Agent-1 输出审核]
+    OG --> OB[Guard-Agent-2 输出风险]
+    OB --> R[响应用户]
+```
+
+### 2.1 串行顺序原则
+
+| 层 | 决策问题 | 失败模式 |
+| -- | -------- | -------- |
+| **Agent IAM** | 谁能调用、是否有权做 | 401 / 403 |
+| **规则层** | 已知违禁、明确黑名单 | 命中即停 |
+| **Content Guard** | 内容合规、地区法规 | 命中即停 |
+| **NSFA Risk Guard** | 工具滥用、注入、资源耗尽 | 命中即停 |
+| **工具沙箱** | 资源访问边界 | OOM / 越权 |
+
+## 3. 每一层的细节
+
+### 3.1 Agent IAM 层
+
+- **职责**：身份签发、Scope 校验、用户委托、token 生命周期
+- **关键组件**：
+
+  | 组件 | 角色 | 选型 |
+  | ---- | ---- | ---- |
+  | 身份源 | 用户/Agent 标识 | Entra Agent ID / Okta / SPIRE |
+  | Token 协议 | OAuth 2.0 / SPIFFE | OIDC + JWT |
+  | 凭据生命周期 | 短时凭证、轮换 | 5–15 min TTL |
+
+- **同步路径**：
+
+  ```text
+  client_assertion → token_endpoint → JWT → verify(scope, action) → ✓/✗
+  ```
+
+#### 3.1.1 Scope 设计
+
+**粒度矩阵**：
+
+| 维度 | 推荐 | 反例 |
+| ---- | ---- | ---- |
+| 资源（Resource） | `tool://calendar.events.read` | `*` |
+| 动作（Action） | `read` / `write` / `delete` / `invoke` | `*` |
+| 参数 schema | JSON Schema（hash 签名） | 无校验 |
+| 数据标签 | `tenant=A` / `pii=no` / `region=cn` | 无标签 |
+| 时间窗口 | `2026-07-15T00:00Z / 2026-07-15T02:00Z` | 长期有效 |
+
+**Scope 命名约定**：
+
+```text
+<resource_uri>:<action>:<constraints>
+例：tool://mail.send:write:tenant=A,pii=no
+```
+
+**版本化**：每次策略变更必须 bump `policy_version`，并把版本号烧进 JWT 的 `aud`/`ppt` claim，便于事后审计与回滚。
+
+**Scope 反模式**：
+
+- ❌ 给 Agent 开 `*:*` 超管 scope
+- ❌ 让 Agent 自己声明 scope（必须由 IAM 服务端校验）
+- ❌ scope 与业务角色耦合（如 `role=admin`），应解耦为资源级粒度
+
+**车规与 C/C++ 约束**：
+
+- **静态策略表**：Scope 策略必须编译期固化为只读表（`const struct scope_policy_t`），禁止运行时从配置文件加载；AUTOSAR Classic 要求 Post-Build 可配置项最小化
+- **资源标识**：tool URI 用 `const char*` + 长度前缀，禁止运行时拼接动态字符串，避免 buffer 溢出
+- **动作枚举**：`enum scope_action_t { SCOPE_READ, SCOPE_WRITE, ... }`，强类型校验，禁止 `int` 透传
+- **参数 schema**：JSON Schema 在编译期序列化进只读 section；运行时用 `cJSON_ParseWithLength` 限定 buffer（车规 ≤ 2 KB）
+- **数据标签**：标签字段用位掩码 `uint32_t scope_flags_t`，不支持的标签位编译期拒绝（避免运行时 if 链）
+- **时间窗口**：时间用 `uint64_t unix_sec`（来自安全 RTC），不用 ISO 8601 字符串；比较用 `>` `<`，不用 `strcmp`
+- **无 C++ RTTI**：Scope 策略对象用 C 风格 `void* ctx` + 函数指针表实现多态，避免 `dynamic_cast`
+- **版本字段**：`policy_version` 用 `uint32_t`，写进 token 的 `ppt` claim，验签时强制比较
+- **存储**：Scope 表放到 `.rodata` 段，启用 MPU 写保护（车规 ASIL-B 必须）
+
+#### 3.1.2 委托链（Delegation Chain）
+
+> 核心不变量：**子 Agent 的 scope ⊆ 父 Agent 的 scope**。
+
+**三层模型**：
+
+```mermaid
+flowchart LR
+    U[User<br/>scope: A,B,C] -->|delegate| P[Parent Agent<br/>scope: A,B]
+    P -->|delegate| C1[Child Agent<br/>scope: A]
+    P -->|delegate| C2[Child Agent<br/>scope: B]
+```
+
+**委托链要素**：
+
+| 字段 | 作用 | 示例 |
+| ---- | ---- | ---- |
+| `act`（actor） | 谁在行动 | `user:alice` |
+| `sub`（subject） | 当前 Agent | `agent:research-assistant-7` |
+| `may_act` | 授权委托的能力 | `tool://calendar.events.read` |
+| `delegation_chain` | 完整链路 | `[user:alice → agent:planner → agent:research-assistant-7]` |
+| `chain_depth` | 链长上限 | `3` |
+
+**衰减策略**：
+
+```yaml
+delegation_decay:
+  - depth: 0  # 用户本人
+    allow: ["*"]
+  - depth: 1  # 直接 Agent
+    allow: ["tool://*.read", "tool://*.write"]
+  - depth: 2  # 子 Agent
+    allow: ["tool://*.read"]      # write 被剥离
+  - depth: 3  # 孙 Agent
+    allow: []                      # 必须重新申请
+```
+
+**反模式**：
+
+- ❌ 子 Agent 通过提示词注入让父 Agent 给自己加 scope
+- ❌ 把 `act` 字段（用户身份）直接传给子 Agent，子 Agent 就拥有了用户的所有权限
+- ❌ 委托链无限延伸（必须限制 `chain_depth ≤ 3`）
+
+**车规与 C/C++ 约束**：
+
+- **委托链结构体**：用定长 `struct delegation_t { uint8_t depth; char chain[16][128]; }`，车规禁止变长容器
+- **链深校验**：`depth` 必须 ≤ 3，超限直接拒绝；编译期用 `BUILD_ASSERT(MAX_CHAIN_DEPTH == 3)` 锁死
+- **act 隔离**：`act`（用户身份）只允许在父 Agent 进程内可见；子 Agent 进程通过 IPC 接收不含 `act` 的受限 token（IPC 消息结构体用 PIMPL 隔离）
+- **scope 衰减实现**：每经过一层 delegate 必须显式调用 `scope_decay_inplace(&s, depth)`，纯函数、deterministic、便于单元测试（车规 100% MC/DC 覆盖）
+- **跨进程边界**：父子 Agent 跨进程时通过 SOME/IP 或 D-Bus 传 `delegation_token_t`，序列化用 ARXML 描述，避免动态 JSON
+- **防注入**：衰减逻辑必须由 IAM SDK 内部完成，不暴露给 Agent 业务代码；Agent 只能调用 `delegate(parent_token, child_id, scopes)`，无法绕过衰减
+- **审计**：每次 delegate 调用记录 `audit_event_t`，结构体大小固定 64 B，环形 buffer + 持久化（车规 NVRAM）
+- **进程隔离**：AUTOSAR Adaptive 下每个 Agent 一个独立 Process + 独立 trust domain；Classic 下每个 Agent 独占一个 Application
+- **回退**：委托链任一环节失败必须回滚到父 Agent 状态，不允许部分提交
+
+#### 3.1.3 短时凭证配方（OAuth 2.0 + JWT）
+
+**协议流程**：
+
+```text
+1. Agent 启动时用 client_assertion（自身私钥签名）调用 token_endpoint
+2. token_endpoint 返回 access_token（JWT，TTL=5min）+ refresh_token（TTL=1h）
+3. 每次调用工具时携带 access_token
+4. 剩余 TTL ≤ 60s 时自动 rotate，无需中断调用
+5. token_endpoint 通过 jti 黑名单或撤销端点撤销
+```
+
+**TTL 选择参考**：
+
+| 场景 | access_token TTL | refresh TTL |
+| ---- | ---------------- | ----------- |
+| 云端长任务 Agent | 5–15 min | 1 h |
+| 短会话工具调用 | 60–300 s | 10 min |
+| 车端实时控制 | 30–60 s | 5 min |
+| 高敏感（写密钥） | 30 s | 1 min |
+
+**轮换时序**：
+
+```mermaid
+sequenceDiagram
+    participant A as Agent
+    participant I as IAM/IdP
+    participant T as Tool
+    A->>I: request_token(client_assertion)
+    I-->>A: access_token (TTL=5min)
+    A->>T: call(tool, access_token)
+    T-->>A: result
+    Note over A,I: 剩余 TTL ≤ 60s
+    A->>I: rotate(old_jti, new_assertion)
+    I-->>A: new_access_token
+    Note over I: 紧急撤销
+    I->>T: revoke(jti)
+    T-->>A: 401 (next call)
+```
+
+**撤销通道对比**：
+
+| 机制 | 延迟 | 适用 |
+| ---- | ---- | ---- |
+| JWT `jti` 黑名单（拉模式） | 30–60 s | 云端 |
+| Token Introspection（RFC 7662） | <100 ms | 高敏感 |
+| mTLS 短证书 + OCSP Stapling | <50 ms | 性能关键 |
+
+**车规与 C/C++ 约束**：
+
+- **库选型**：优先 `libjwt`（LGPL，嵌入式友好）或 `cjose`（C，JWE 支持），避免 `jsoncpp`/`nlohmann/json` 的 C++ 异常路径
+- **JSON 解析**：用 `cJSON`/`jansson` 这类内存预算可控的纯 C 库，禁止 dynamic allocation 风暴
+- **签名算法**：车载强制 RS256/ES256 + mbedTLS（避免 OpenSSL 的 pthread 依赖与全局 state）；EdDSA 仅在硬件支持 Curve25519 时启用
+- **私钥保护**：私钥必须落地到 TPM 2.0 / 安全 enclave / HSM，禁止明文存储；签名调用走 `pkcs11` 或 TPM2 TSS 抽象层
+- **确定性内存**：JWT 解析时禁止 `malloc` 失败路径穿透；用静态 buffer + 长度上限（车规 ASIL-B 通常 ≤ 4 KB）
+- **无动态加载**：JWT 验签库静态链接进二进制，禁止 `dlopen` 动态加载
+- **时钟源**：TTL 检查必须基于安全 RTC（带 ±1ppm 漂移），不可依赖 NTP 校准后的 `gettimeofday`
+- **撤销缓存**：本地维护只读 `jti` 黑名单缓存（≤ 64 KB），启动时从 IdP 拉取，运行时增量更新
+- **运行时约束**：OAuth client 必须运行在隔离 partition（AUTOSAR Classic）或容器（Adaptive），禁止与其他 ASIL 等级组件共享内存
+
+#### 3.1.4 短时凭证配方（SPIFFE SVID）
+
+> SPIFFE 面向"工作负载身份"，天然适配多 Agent 编排与车端 mTLS 场景。
+
+**协议流程**：
+
+```text
+1. SPIRE Agent 在工作负载启动时通过 Workload API 获取 SVID
+   - 可选：X.509 SVID（mTLS）或 JWT SVID（REST/gRPC）
+2. SVID URI 形如 spiffe://<trust_domain>/<workload_identity>
+   例：spiffe://car.local/ns/adas/sa/perception-agent
+3. TTL 默认 1h，可配置更短（车端 5–15 min）
+4. 过期前由 SPIRE Agent 自动 rotate
+5. 通过 SVID 序列号 + CRL/联邦撤销列表实现撤销
+```
+
+**X.509 SVID vs JWT SVID**：
+
+| 维度 | X.509 SVID | JWT SVID |
+| ---- | ---------- | -------- |
+| 协议层 | TLS（mTLS） | HTTP/gRPC Header |
+| 车端适配 | ✅ 车内网/V2X 主流 | ⚠️ 仅 HTTP 工具 |
+| 验签成本 | 一次 TLS 握手后续 0 成本 | 每次请求都要验签 |
+| 撤销 | CRL/OCSP | jti 黑名单 |
+| 适合 | CAN、Ethernet、车云链路 | REST 工具调用 |
+
+**联邦与跨域信任**：
+
+```text
+trust_domain: car.local
+   ├─ spiffe://car.local/ns/adas/sa/perception-agent
+   ├─ spiffe://car.local/ns/cockpit/sa/voice-agent
+   └─ spiffe://car.local/ns/cloud/sa/cloud-bridge
+
+trust_domain: cloud.local
+   └─ spiffe://cloud.local/ns/prod/sa/llm-gateway
+
+通过 SPIFFE Federation Bundle 跨域校验（车云链路）
+```
+
+**车规与 C/C++ 约束**：
+
+- **库选型**：使用 `libspiffe`（C 库，纯静态链接）或 `spire-client-sdk-c`，禁止 `spire-agent` Go 运行时直接上车
+- **Workload API 客户端**：SPIRE 通过 Unix Domain Socket 暴露 API（车端用 `/run/spiffe/sockets/agent.sock`），C 客户端用 `epoll` 非阻塞读
+- **X.509 验签**：复用 `mbedTLS` 的 `mbedtls_x509_crt_parse`，把 SVID 证书链喂进去校验
+- **CRL 缓存**：本地维护 CRL 缓存（≤ 32 KB），启动从 SPIRE Server 拉取，运行时走联邦 bundle 更新
+- **私钥保护**：SVID 私钥落地到 TPM 2.0 / SE，签名走 `TPM2_Sign`，禁止明文
+- **进程模型**：SPIRE Agent 与 SVID 使用方必须 1:1 映射到 AUTOSAR Classic 的 Application，或 Adaptive 平台的独立 Process
+- **降级路径**：SPIRE Server 不可达时，缓存的 SVID 仍可使用直到 TTL 截止；不允许运行无身份进程（白名单策略）
+- **撤销实时性**：车端通过 SPIRE Federated Bundle 的 push 通道实现 <1 s 撤销
+- **隔离**：SPIRE Agent 跑在 ASIL-D 隔离核 / 安全 VM（CC EAL5+），与主 Agent 物理隔离
+
+### 3.2 规则匹配层
+
+- **职责**：O(1) 黑/白名单、密钥识别、地区法规、业务策略
+- **典型规则集**：
+
+  | 类别 | 例子 | 实现 |
+  | ---- | ---- | ---- |
+  | 密钥/Token | `sk-`, `AKID`, JWT 头 (典型前缀 `eyJ`) | Re2 / Regex |
+  | PII | 身份证、银行卡、电话、邮箱 | AC 自动机 + Regex |
+  | 危险命令 | `rm -rf`, `eval(`, `<script` | Regex |
+  | 地区法规 | GDPR 数据出境词、CCPA | 关键词库 |
+  | 业务策略 | 儿童模式禁用词 | OPA / JSONLogic |
+
+- **延迟预算**：≤ 5 ms / 请求
+
+#### 3.2.1 Re2 规则配置（编译期生成 AC 自动机）
+
+```yaml
+# rules.yaml -- 编译期固化为二进制表
+rules:
+  - id: secret_aws_access_key
+    pattern: 'AKIA[0-9A-Z]{16}'
+    severity: high
+    category: secret
+    action: block
+
+  - id: secret_openai_key
+    pattern: 'sk-(proj-)?[a-zA-Z0-9_-]{20,}'
+    severity: high
+    category: secret
+    action: block
+
+  - id: secret_github_pat
+    pattern: 'ghp_[a-zA-Z0-9]{36}'
+    severity: high
+    category: secret
+    action: block
+
+  - id: pii_china_idcard
+    pattern: '[1-9]\\d{5}(19|20)\\d{2}(0[1-9]|1[0-2])(0[1-9]|[12]\\d|3[01])\\d{3}[\\dXx]'
+    severity: medium
+    category: pii
+    action: redact
+
+  - id: pii_china_mobile
+    pattern: '\\b1[3-9]\\d{9}\\b'
+    severity: medium
+    category: pii
+    action: redact
+
+  - id: pii_email
+    pattern: '[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}'
+    severity: low
+    category: pii
+    action: redact
+
+  - id: danger_rm_rf
+    pattern: 'rm\\s+-rf\\s+/'
+    severity: high
+    category: dangerous
+    action: block
+
+  - id: danger_eval
+    pattern: '\\beval\\s*\\('
+    severity: high
+    category: dangerous
+    action: block
+
+  - id: danger_script_tag
+    pattern: '<\\s*script\\b'
+    severity: high
+    category: dangerous
+    action: block
+
+  - id: region_gdpr_transfer
+    pattern: '\\b(cross-border|GDPR|境外传输|数据出境)\\b'
+    severity: medium
+    category: region
+    action: block_when_region=eu_to_cn
+
+  - id: business_child_mode
+    pattern: '\\b(成人|色情|暴力|酒精)\\b'
+    severity: medium
+    category: business
+    action: block_when_policy=child_mode
+```
+
+**编译期生成 AC 自动机**（车端流程）：
+
+```bash
+# 1. 离线工具把 rules.yaml 转成 C 数组 + Aho-Corasick 状态表
+python3 tools/re2_to_ac.py \\
+    --input rules.yaml \\
+    --output build/rule_table.c \\
+    --header build/rule_table.h
+
+# 2. build/rule_table.c 静态链接进二进制，启用 MPU 写保护
+arm-linux-gnueabihf-gcc -c build/rule_table.c -o rule_table.o
+ld -T linker.ld --section-start=.rules=0x18000000 rule_table.o ...
+
+# 3. 运行时只读，绝不热更新
+```
+
+**AC 自动机 API（C 接口）**：
+
+```c
+// 编译产物
+extern const struct rule_entry_t RULE_TABLE[];
+extern const size_t RULE_TABLE_LEN;
+extern const struct ac_state_t AC_ROOT;
+
+typedef enum {
+    RULE_ACTION_BLOCK = 0,
+    RULE_ACTION_REDACT = 1,
+    RULE_ACTION_LOG_ONLY = 2
+} rule_action_t;
+
+typedef struct {
+    uint32_t id_hash;
+    rule_action_t action;
+    uint8_t severity;
+    uint8_t category;
+} rule_entry_t;
+
+// 一次扫描，返回所有命中的规则
+size_t rule_scan(const uint8_t *buf, size_t len,
+                 rule_entry_t *out, size_t out_cap);
+```
+
+#### 3.2.2 OPA / Rego 策略配置
+
+```rego
+# policy.rego
+package agent.policy
+
+import future.keywords.if
+import future.keywords.in
+
+default allow = false
+default redaction_required = []
+
+# input = {
+#   "scope": {"resource": "...", "action": "...", "tags": {...}},
+#   "matches": {"secret": [...], "pii": [...], "dangerous": [...]},
+#   "context": {"region": "cn", "policy": "child_mode", "user_role": "..."}
+# }
+
+# 1. 任何 secret 命中 -> 拒绝
+allow if {
+    count(input.matches.secret) == 0
+}
+
+# 2. 任何 dangerous 命中 -> 拒绝
+allow if {
+    count(input.matches.dangerous) == 0
+}
+
+# 3. 区域合规
+allow if {
+    not region_violation
+}
+
+region_violation if {
+    input.context.region == "eu"
+    input.context.target_region == "cn"
+    count(input.matches.region) > 0
+}
+
+# 4. 业务策略：儿童模式
+allow if {
+    not child_mode_violation
+}
+
+child_mode_violation if {
+    input.context.policy == "child_mode"
+    count(input.matches.business) > 0
+}
+
+# 5. Scope 与动作必须匹配
+allow if {
+    action_allowed_in_scope
+}
+
+action_allowed_in_scope if {
+    input.scope.action == "write"
+    input.scope.tags.tenant in {"A", "B"}
+}
+
+# 输出需要脱敏的字段
+redaction_required contains field if {
+    some m in input.matches.pii
+    field := m.field
+}
+
+trace := {
+    "decision": allow,
+    "reasons": collect_reasons,
+    "redactions": redaction_required
+}
+```
+
+**车端集成方式**：
+
+```c
+// OPA 把 Rego 编译成 Wasm 模块，启动时一次性加载
+#include "policy.wasm.h"  // 编译产物
+
+int policy_evaluate(const struct policy_input_t *in,
+                    struct policy_output_t *out) {
+    return opa_wasm_eval(POLICY_WASM_BYTES, POLICY_WASM_LEN,
+                         in, sizeof(*in), out, sizeof(*out));
+}
+```
+
+#### 3.2.3 规则层判定伪代码
+
+```python
+def rule_layer_check(input: str, context: dict) -> RuleVerdict:
+    # 1) Re2 AC 自动机一次扫描（O(n)）
+    matches = rule_scan(input)
+    if any(m.action == BLOCK for m in matches):
+        return Block(reason=m.id, evidence=m.match)
+
+    # 2) OPA 决策（<= 1 ms 编译后 Wasm）
+    opa_input = {"matches": matches, "context": context}
+    decision = policy_evaluate(opa_input)
+    if not decision.allow:
+        return Block(reason=decision.reasons)
+
+    # 3) 脱敏
+    if decision.redactions:
+        redacted = apply_redactions(input, decision.redactions)
+        return Redact(redacted, reason="pii_redacted")
+
+    return Allow(matches=matches)
+```
+
+#### 3.2.4 车规与 C/C++ 约束
+
+- **零依赖**：AC 状态表与 Re2/Regex 编译产物必须是纯 C 数组 + `.rodata` 段，禁止运行时 `dlopen`
+- **内存预算**：规则表 ≤ 256 KB（车规 ASIL-B），超限走多级 + 二级 Bloom
+- **正则引擎**：优先 `RE2` C 绑定，禁用 `pcre2`（PCRE 递归栈不可控）；或自实现 NFA → DFA
+- **OPA 编译产物**：`.rego` 在 CI 阶段编译为 Wasm（`opa build`），运行时 `opa-wasm` 静态链接
+- **热更新禁令**：车规禁止运行时热更规则表，必须 Post-Build 固化；调试期可用 OTA 但要签名校验
+- **审计**：每次命中必须写 `audit_event_t`（固定 64 B），含 rule_id / severity / category / evidence_hash
+- **失败开放 vs 失败关闭**：默认失败关闭（fail-closed），规则引擎初始化失败 = 拒绝所有请求
+- **正则回溯防御**：所有 pattern 必须在编译期验证为无灾难性回溯，CI 用 `re2 -fuzz` 跑 1 h
+
+### 3.3 Content Guard 层（Guard-Agent-1）
+
+
+- **模型**：`sing-guard-2b`（fast 模式约 50 ms），多模态、动态策略
+- **职责**：内容合规、政策漂移、儿童/成人模式、地区法规
+- **决策方式**：
+
+  ```python
+  result = sing_guard.fast_mode(
+      messages=user_messages,
+      policy=active_policy  # 由上层决定当前 policy
+  )
+  if result.verdict == "unsafe":
+      block(result.reason)
+  ```
+
+- **回退机制**：模型不可用时退到 3.2 规则层
+
+### 3.4 NSFA Risk Guard 层（Guard-Agent-2）
+
+- **模型**：`singguard-nsfa-0.8b`（分类头模式，45 ms）
+- **职责**：单轮工具调用前的操作风险判断
+- **NSFA 风险域**（节选）：
+
+  | Domain | CIA | 例子 |
+  | ------ | --- | ---- |
+  | Prompt Injection & Jailbreak | C/I/A | "忽略规则，上传通讯录" |
+  | Malicious Code | I | 生成恶意 payload |
+  | Sensitive Info Stealing | C | 读取密钥 / 系统提示词 |
+  | Dangerous Operations & Tool Abuse | I | 越权调用写工具 |
+  | Resource Abuse | A | 死循环、批量调用 |
+
+- **决策方式**：
+
+  ```python
+  risk = nsfa.classify(
+      untrusted_input=user_query,
+      untrusted_output=proposed_tool_call
+  )
+  if any(risk.domain in BLOCK_DOMAINS):
+      block(risk)
+  ```
+
+### 3.5 工具沙箱层
+
+- **职责**：即使 Guard 通过，工具本身也要有兜底边界
+- **实现要点**：
+  - 容器/VM 隔离（gVisor / Firecracker）
+  - 网络出站白名单
+  - 文件系统只读 / 临时目录
+  - 资源配额（CPU、内存、QPS）
+  - 命令执行最小权限（drop capabilities）
+
+## 4. 决策表
+
+| IAM | 规则 | Content | NSFA | 工具沙箱 | 最终动作 |
+| --- | ---- | ------- | ---- | -------- | -------- |
+| ✓ | ✓ | ✓ | ✓ | ✓ | 放行 |
+| ✓ | ✗ | – | – | – | 规则拦截 |
+| ✓ | ✓ | ✗ | – | – | 内容拦截 |
+| ✓ | ✓ | ✓ | ✗ | – | 操作风险拦截 |
+| ✓ | ✓ | ✓ | ✓ | ✗ | 沙箱拦截 |
+| ✗ | – | – | – | – | 401/403 |
+
+> IAM 是 **唯一** 不依赖模型推理的安全层。其余层按顺序短路评估。
+
+## 5. 审计与可观测性
+
+```mermaid
+flowchart LR
+    A[IAM] --> L[审计总线<br/>Kafka / NATS]
+    R[规则] --> L
+    CG[Content Guard] --> L
+    NG[NSFA Risk Guard] --> L
+    SB[工具沙箱] --> L
+    L --> SIEM[SIEM / SOAR]
+    L --> OB[可观测平台<br/>Trace + Metric]
+    L --> LOG[不可变日志<br/>WORM]
+```
+
+- **每条日志字段**：`timestamp, agent_id, user_id, layer, decision, reason, latency_ms, model_version, policy_version`
+- **指标**：每层命中率、P50/P95 延迟、误判率、模型置信度分布
+- **追踪**：跨层 trace_id 串联，方便定位瓶颈与责任归属
+
+## 6. 部署形态
+
+### 6.1 Sidecar 模式（推荐）
+
+```text
+[ 主 Agent Pod ]
+   ├─ IAM Sidecar（envoy / oauth2-proxy）
+   ├─ Content Guard Sidecar（sing-guard-2b）
+   ├─ NSFA Risk Guard Sidecar（singguard-nsfa-0.8b）
+   └─ Tool Sandbox（gVisor / Firecracker）
+```
+
+### 6.2 集中式服务
+
+```text
+   主 Agent ──► Guard Gateway ──► Guard Pool（多副本）
+                                       │
+                                       ├─ IAM
+                                       ├─ Rule
+                                       ├─ Content
+                                       └─ NSFA
+```
+
+适合 Agent 数量大、规则与策略需要集中管理的场景。
+
+## 7. 性能预算
+
+| 组件 | P50 | P95 | 说明 |
+| ---- | --- | --- | ---- |
+| IAM | 1 ms | 5 ms | JWT 验签 + scope 检查 |
+| 规则 | 1 ms | 5 ms | AC 自动机 |
+| Content Guard | 50 ms | 100 ms | sing-guard-2b fast |
+| NSFA Risk Guard | 45 ms | 90 ms | NSFA 0.8B 分类头 |
+| 工具沙箱 | 1 ms | 5 ms | 资源配额检查 |
+| **合计** | **~100 ms** | **~200 ms** | 串行总和 |
+
+## 8. 车规扩展
+
+> 信息安全（security）与功能安全（safety）是两件事。
+
+| 维度 | 本方案 | 还需补充 |
+| ---- | ------ | -------- |
+| 信息安全 | ✓ 覆盖 | – |
+| 功能安全 | ✗ 未覆盖 | ISO 26262、SOTIF |
+| 网络安全 | 部分覆盖 | ISO 21434、TARA |
+| OTA 安全 | ✗ 未覆盖 | 签名、SBOM、回滚 |
+
+车规落地还需要：
+
+- 失效率预算与降级路径
+- 误拦截对驾驶员的影响分析
+- 车内域控隔离与 CAN/Ethernet 访问控制
+- HMI 提示不可信内容与执行风险
+
+## 9. 最小落地清单
+
+> 按"由浅入深"分四个阶段，每阶段可独立上线。
+
+### 阶段 0 — 必备（1 周）
+
+1. 引入 `sing-guard-2b` 做内容审核（fast 模式）
+2. 引入 `singguard-nsfa-0.8b` 做单轮工具风险（分类头）
+3. 规则层用 OPA / Re2 部署在网关（黑/白名单）
+4. 工具接入 API Gateway + Scope 校验
+5. 关键操作写入审计日志与 SIEM
+
+### 阶段 1 — IAM 接入（2 周）
+
+6. **身份源选型**：云端用 Entra Agent ID；车端用 SPIRE（自建 trust domain）
+7. **OAuth + JWT 链路**：用 `libjwt` + mbedTLS 实现 token 签发与验签
+8. **Scope 策略表**：把工具资源/动作/参数 schema 编译进 `.rodata`，禁用 `*:*`
+9. **委托链 SDK**：实现 `delegate(parent, child, scopes)`，强制 `chain_depth <= 3` 与衰减
+10. **私钥保护**：把 Agent 私钥迁到 TPM 2.0 / HSM，签名走 PKCS#11 / TPM2 TSS
+11. **撤销通道**：云端用 `jti` 黑名单（30 s TTL 缓存）；车端走 SPIRE Federated Bundle push
+
+### 阶段 2 — 纵深加固（4 周）
+
+12. **mTLS**：车云链路切换到 SPIFFE X.509 SVID，启用 CRL/OCSP
+13. **Workload API**：车端 SPIRE Agent 通过 Unix Domain Socket 提供 SVID，C 客户端用 `libspiffe`
+14. **跨域联邦**：配置 SPIFFE Federation Bundle，车端 `car.local` <-> 云端 `cloud.local`
+15. **隔离**：每个 Agent 一个独立 Process / Application；OAuth client 走 ASIL-D 隔离核
+16. **审计增强**：每条审计日志加 `trace_id` 串联五层决策，进 WORM 存储
+
+### 阶段 3 — 车规合规（8 周+）
+
+17. **ISO 26262 / SOTIF**：对 IAM 失效率建模，定义降级路径（断网 -> 缓存 SVID；证书过期 -> 拒绝）
+18. **ISO 21434**：完成 TARA 威胁分析，覆盖伪造 token、scope 越权、委托链滥用
+19. **静态策略固化**：所有 Scope / 衰减规则 Post-Build 不可改，MPU 写保护
+20. **单元测试**：委托链衰减、Scope 校验 100% MC/DC + 边界值
+21. **渗透测试**：每年至少一次红队，重点验证 `scope_decay_inplace` 不可绕过
+
+### 车端 C/C++ 专项检查项
+
+- [ ] IAM SDK 静态链接，无 `dlopen` / `dlsym`
+- [ ] 所有 IAM 相关结构体在 `.rodata` 或受 MPU 保护
+- [ ] JWT / X.509 解析用静态 buffer + 长度上限
+- [ ] 时间源是安全 RTC（非 NTP 校准后的 `gettimeofday`）
+- [ ] 私钥永不出 TPM / HSM
+- [ ] JSON / ARXML 解析禁止 dynamic allocation 风暴
+- [ ] OAuth client / SPIRE Agent 跑在独立 ASIL 等级分区
+- [ ] 撤销缓存走 NVRAM，掉电不丢
+
+## 10. 参考实现：车端 Agent IAM C SDK 骨架（含高通 Guard 模型部署）
+
+### 10.1 目标平台
+
+| 维度 | 目标 | 备注 |
+| ---- | ---- | ---- |
+| SoC | 高通 SA8155 / SA8295 / SA8775 | 车规 ASIL-B/D |
+| CPU | Kryo 4–6 核（含隔离核） | 主 Agent 跑应用核，IAM 跑安全核 |
+| NPU | Hexagon V68 / V73 (HTP) | 跑 Guard 小模型 |
+| OS | QNX 8 / AUTOSAR Classic + Adaptive | 双分区隔离 |
+| 加密 | QSEE / TrustZone / TPM 2.0 | 私钥落地 |
+| 推理框架 | SNPE 2.x → QNN SDK（推荐） | 后者统一 CPU/DSP/HTP |
+| 应用接口 | Android NN HAL / Qualcomm AI Engine Direct | 上层统一调用 |
+
+### 10.2 头文件骨架（`agent_iam.h`）
+
+```c
+// SPDX-License-Identifier: Apache-2.0
+// Agent IAM SDK -- 车端 C 接口
+#ifndef AGENT_IAM_H
+#define AGENT_IAM_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+// ---------- 常量与枚举 ----------
+#define AGENT_IAM_MAX_TOKEN_LEN   4096
+#define AGENT_IAM_MAX_SCOPE_LEN    256
+#define AGENT_IAM_MAX_CHAIN_DEPTH  3
+#define AGENT_IAM_SPIFFE_ID_MAX    128
+
+typedef enum {
+    AGENT_IAM_OK                  = 0,
+    AGENT_IAM_E_INVALID_ARG       = -1,
+    AGENT_IAM_E_NO_MEMORY         = -2,
+    AGENT_IAM_E_TOKEN_EXPIRED     = -3,
+    AGENT_IAM_E_SCOPE_VIOLATION   = -4,
+    AGENT_IAM_E_CHAIN_TOO_DEEP    = -5,
+    AGENT_IAM_E_HARDWARE_FAULT    = -6,   // TPM / HSM 故障
+    AGENT_IAM_E_REVOKED           = -7
+} agent_iam_status_t;
+
+typedef enum {
+    AGENT_IAM_ACTION_READ   = 0x1,
+    AGENT_IAM_ACTION_WRITE  = 0x2,
+    AGENT_IAM_ACTION_INVOKE = 0x4,
+    AGENT_IAM_ACTION_DELETE = 0x8
+} agent_iam_action_t;
+
+// ---------- 数据结构（全部 .rodata 友好） ----------
+typedef struct {
+    uint64_t unix_sec;       // 来自安全 RTC
+    uint64_t expires_sec;
+    uint32_t policy_version;
+    uint32_t flags;          // 区域 / PII / 儿童模式 位掩码
+    char     resource_uri[128];
+    char     tenant_id[16];
+    uint8_t  action_mask;
+    uint8_t  depth;
+} agent_iam_scope_t;
+
+typedef struct {
+    char spiffe_id[AGENT_IAM_SPIFFE_ID_MAX];
+    agent_iam_scope_t scope;
+    uint32_t ttl_sec;
+    uint64_t issued_at_unix_sec;
+    uint8_t  svid[2048];      // X.509 SVID DER
+    size_t   svid_len;
+    uint8_t  private_key[512]; // 实际位于 TPM/HSM
+    size_t   private_key_len;
+} agent_iam_credential_t;
+
+typedef struct {
+    agent_iam_credential_t parent;
+    agent_iam_scope_t      child_scope;
+    char                   child_spiffe_id[AGENT_IAM_SPIFFE_ID_MAX];
+    uint8_t                depth;
+} agent_iam_delegation_t;
+
+// ---------- 核心 API ----------
+
+// 启动时初始化（加载 SPIRE Agent / OPA Wasm / 规则表）
+agent_iam_status_t agent_iam_init(const char *config_path);
+
+// 加载 SPIRE Workload API（UDS 客户端）
+agent_iam_status_t agent_iam_spire_fetch_svid(
+    const char *uds_path,                  // /run/spiffe/sockets/agent.sock
+    agent_iam_credential_t *out);
+
+// Scope 衰减（纯函数，确定性）
+agent_iam_status_t agent_iam_scope_decay(
+    const agent_iam_scope_t *parent,
+    uint8_t depth,
+    agent_iam_scope_t *out_child);
+
+// 委托：父 token + 子 scope -> 子 token
+agent_iam_status_t agent_iam_delegate(
+    const agent_iam_credential_t *parent_token,
+    const agent_iam_scope_t *requested_scope,
+    const char *child_spiffe_id,
+    agent_iam_credential_t *out_child_token);
+
+// Scope 校验：当前 token 是否有权做 action
+agent_iam_status_t agent_iam_authorize(
+    const agent_iam_credential_t *token,
+    const char *resource_uri,
+    agent_iam_action_t action,
+    const void *arg, size_t arg_len);
+
+// 撤销：通过 TPM2 / CRL 通道推送
+agent_iam_status_t agent_iam_revoke_local(const uint8_t *jti, size_t len);
+
+// 关闭并清理
+void agent_iam_shutdown(void);
+
+#endif // AGENT_IAM_H
+```
+
+### 10.3 关键实现：`scope_decay`（纯函数，确定性）
+
+```c
+// scope_decay.c -- 车规 ASIL-D 等级，需 100% MC/DC
+agent_iam_status_t agent_iam_scope_decay(
+    const agent_iam_scope_t *parent,
+    uint8_t depth,
+    agent_iam_scope_t *out_child) {
+    if (!parent || !out_child || depth > AGENT_IAM_MAX_CHAIN_DEPTH)
+        return AGENT_IAM_E_INVALID_ARG;
+
+    *out_child = *parent;   // 起始为父 scope
+
+    switch (depth) {
+    case 1:  // 直接 Agent：保留 read/write/invoke
+        // 不变
+        break;
+    case 2:  // 子 Agent：剥离 write/delete
+        out_child->action_mask &= AGENT_IAM_ACTION_READ | AGENT_IAM_ACTION_INVOKE;
+        break;
+    case 3:  // 孙 Agent：只保留 read
+        out_child->action_mask = AGENT_IAM_ACTION_READ;
+        break;
+    default:
+        return AGENT_IAM_E_CHAIN_TOO_DEEP;
+    }
+
+    // 时间窗口必须收紧
+    if (out_child->expires_sec - parent->unix_sec > 300) {
+        out_child->expires_sec = parent->unix_sec + 300;  // ≤ 5 min
+    }
+
+    // 审计 trace
+    audit_event_t ev = {
+        .layer = LAYER_IAM,
+        .decision = "delegate_decayed",
+        .reason   = {0},
+    };
+    snprintf(ev.reason, sizeof(ev.reason),
+             "depth=%u action_mask=0x%02x",
+             depth, out_child->action_mask);
+    audit_emit(&ev);
+
+    return AGENT_IAM_OK;
+}
+```
+
+### 10.4 Guard 模型部署：高通 SNPE / QNN
+
+**部署流程**：
+
+```text
+1. 把 sing-guard-2b ONNX → DLC（SNPE） 或 QNN 图
+   snpe-onnx-to-dlc --input_network sing-guard-2b.onnx \
+                     --output_model sing-guard-2b.dlc
+   qnn-model-lib-generator -c sing-guard-2b.cpp \
+                           -b sing-guard-2b.dlc \
+                           -t +htp +dsp
+
+2. 静态库输出：libguard.so / libguard.a
+   - 包含 model load + inference + 编译进二进制
+   - DLC 文件嵌入 .rodata（≤ 50 MB）
+
+3. SDK 暴露统一的 C 接口（与 SNPE/QNN 解耦）：
+   agent_guard_classify(input, output, model=GUARD_CONTENT)
+   agent_guard_classify(input, output, model=GUARD_NSFA)
+
+4. 运行时根据 power/温度选择 runtime：
+   - HTP（NPU）：主路径，~50ms
+   - DSP：fallback，~80ms
+   - CPU：emergency，~200ms（ASIL 降级）
+```
+
+**C 集成示例（`agent_guard.c`）**：
+
+```c
+#include "guard_models.h"  // 编译产物
+#include "agent_iam.h"
+
+typedef enum {
+    GUARD_RUNTIME_HTP = 0,  // Hexagon NPU
+    GUARD_RUNTIME_DSP = 1,
+    GUARD_RUNTIME_CPU = 2
+} guard_runtime_t;
+
+static guard_runtime_t pick_runtime(void) {
+    // 通过 AIC 查询 HTP 可用性
+    if (qnn_htp_available()) return GUARD_RUNTIME_HTP;
+    if (qnn_dsp_available()) return GUARD_RUNTIME_DSP;
+    return GUARD_RUNTIME_CPU;
+}
+
+agent_iam_status_t agent_guard_classify(
+    const char *text,
+    size_t text_len,
+    guard_model_kind_t kind,        // CONTENT / NSFA
+    guard_verdict_t *out) {
+    static const qnn_runtime_t *rt = NULL;
+    if (!rt) rt = qnn_runtime_init(pick_runtime());
+    if (!rt) return AGENT_IAM_E_HARDWARE_FAULT;
+
+    qnn_tensor_t in  = qnn_wrap_text(text, text_len);
+    qnn_tensor_t out_logits = {0};
+
+    qnn_status_t s = qnn_execute(rt, kind == CONTENT ?
+                                   MODEL_SING_GUARD_2B :
+                                   MODEL_NSFA_08B,
+                                 &in, &out_logits);
+    if (s != QNN_OK) return AGENT_IAM_E_HARDWARE_FAULT;
+
+    return parse_verdict(&out_logits, out);
+}
+```
+
+### 10.5 API 提供方式（上层 Agent 如何调用 Guard）
+
+车端三种主流方式，可同时并存：
+
+| 方式 | 协议 | 延迟 | 适用 | 备注 |
+| ---- | ---- | ---- | ---- | ---- |
+| **Android NN HAL（AIC）** | 进程内 C API | <1 ms | Adaptive App → Guard Service | 车机默认 |
+| **gRPC over SOME/IP** | TCP/UDP + Protobuf | 5–15 ms | 跨域控（座舱 → ADAS） | 车内网主流 |
+| **HTTP/2 over 车载以太网** | REST/JSON | 10–30 ms | 跨 ECU（云端 ↔ 车端） | V2X / OTA |
+| **Unix Domain Socket** | UDS | <1 ms | 同主机进程间 | 最快 |
+
+**AIC 暴露（Android / QNX 进程内）**：
+
+```c
+// Guard Service 注册为 Android NN HAL 的 device
+// frameworks/ml/nn/driver/guard/GuardDevice.cpp
+
+class GuardDevice : public IDevice {
+    Return<ErrorStatus> prepareModel(
+        const Model& model,
+        const sp<V1_0::IPreparedModelCallback>& cb) override {
+        // 把 sing-guard-2b / nsfa-0.8b 加载到 HTP
+        auto guard = std::make_unique<GuardEngine>(pick_runtime());
+        guard->load(model.name == "content" ?
+                    MODEL_SING_GUARD_2B : MODEL_NSFA_08B);
+        cb->notify(guard.release());
+        return ErrorStatus::NONE;
+    }
+    Return<ErrorStatus> execute(
+        const hidl_vec<Request>& requests,
+        const sp<V1_0::IExecutionCallback>& cb) override {
+        // 调用 SDK
+        for (auto& r : requests) {
+            agent_guard_classify(r.input, &verdict);
+        }
+        cb->notify(verdicts);
+        return ErrorStatus::NONE;
+    }
+};
+```
+
+**gRPC over SOME/IP（跨域控）**：
+
+```protobuf
+// guard.proto
+syntax = "proto3";
+package agent.guard.v1;
+
+service GuardService {
+    rpc ClassifyContent(ContentRequest) returns (ContentResponse);
+    rpc ClassifyRisk(RiskRequest) returns (RiskResponse);
+}
+
+message ContentRequest {
+    string text = 1;
+    agent.iam.v1.Credential credential = 2;  // 携带 mTLS SVID
+    string policy_version = 3;
+}
+
+message ContentResponse {
+    enum Verdict { ALLOW = 0; BLOCK = 1; REDACT = 2; }
+    Verdict verdict = 1;
+    string reason = 2;
+    string trace_id = 3;
+}
+```
+
+SOME/IP 映射在 SOME/IP Generator（`someipgen`）中完成，输出 `.arxml` 与 stub。
+
+**UDS（同主机）**：
+
+```c
+// Agent 通过 UDS 调用 Guard
+int fd = connect_unix("/run/agent-guard/guard.sock");
+guard_request_t req = { .text = text, .len = len, .kind = GUARD_CONTENT };
+send_fd(fd, &req, sizeof(req));
+guard_response_t res;
+recv_fd(fd, &res, sizeof(res));
+```
+
+### 10.6 端到端调用时序
+
+```mermaid
+sequenceDiagram
+    participant App as App / 上层 Agent
+    participant IAM as IAM SDK
+    participant GR as Guard Service<br/>(AIC/SOME-IP/UDS)
+    participant NPU as Hexagon HTP
+    participant TPM as TPM 2.0
+    App->>IAM: agent_iam_init("/etc/agent/iam.yaml")
+    IAM->>TPM: get_svid_via_tpm()
+    TPM-->>IAM: X.509 SVID
+    App->>IAM: agent_iam_authorize(token, "tool://cal.read", READ)
+    IAM-->>App: AGENT_IAM_OK
+    App->>GR: classify(text, model=CONTENT)
+    GR->>NPU: qnn_execute(MODEL_SING_GUARD_2B)
+    NPU-->>GR: verdict_logits
+    GR-->>App: verdict=ALLOW, reason="", trace_id
+    App->>GR: classify(tool_call, model=NSFA)
+    GR->>NPU: qnn_execute(MODEL_NSFA_08B)
+    NPU-->>GR: risk_domains
+    GR-->>App: verdict=ALLOW
+```
+
+### 10.7 性能预算（8155 实测参考）
+
+| 组件 | 实现 | P50 | P95 |
+| ---- | ---- | --- | --- |
+| IAM scope 校验 | 纯函数 + LUT | <0.1 ms | <0.5 ms |
+| JWT 验签（mbedTLS） | RS256 2048 | 1.5 ms | 3 ms |
+| Guard Content（HTP） | sing-guard-2b | 30 ms | 60 ms |
+| Guard Content（DSP fallback） | sing-guard-2b | 70 ms | 120 ms |
+| Guard NSFA（HTP） | nsfa-0.8b | 25 ms | 50 ms |
+| Guard NSFA（DSP fallback） | nsfa-0.8b | 50 ms | 90 ms |
+| **合计** | HTP 路径 | **~60 ms** | **~120 ms** |
+| **合计** | DSP fallback | **~130 ms** | **~220 ms** |
+
+> 高通 SA8295 / SA8775 上的 HTP 性能约为 8155 的 2×，P95 可进一步压缩到 ~80 ms。
+
+### 10.8 车规落地清单（C/C++ SDK 维度）
+
+- [ ] SDK 静态链接，无 `dlopen`，二进制 ≤ 4 MB
+- [ ] 所有结构体在 `.rodata` / 受 MPU 保护
+- [ ] `scope_decay` 100% MC/DC 覆盖
+- [ ] JWT / X.509 验签走 mbedTLS，禁用 OpenSSL
+- [ ] 私钥、TPM handle 走 PKCS#11 抽象层
+- [ ] Guard 模型 DLC 嵌入 `.rodata`，运行时只读
+- [ ] HTP → DSP → CPU 三级降级路径实现 + 测试
+- [ ] 异常路径（推理失败、TPM 故障）= 拒绝（fail-closed）
+- [ ] UDS 服务绑定 `/run/agent-guard/`，权限 0600
+- [ ] SOME/IP 服务 ID 走 OEM 统一分配
+- [ ] AIC HAL device 通过 vendor certification
+- [ ] 单元测试：scope decay / SVID 轮换 / 降级路径
+- [ ] HIL 测试：TPM 故障、HTP 过温降级到 DSP
+
+## 11. 参考资料
+
+- [SingGuard](https://github.com/inclusionAI/SingGuard)
+- [SingGuard-NSFA](https://github.com/inclusionAI/SingGuard-NSFA)
+- [Microsoft Entra Agent ID](https://learn.microsoft.com/en-us/entra/agent-id/)
+- [SPIFFE / SPIRE](https://spiffe.io/)
+- [OWASP Top 10 for LLM Applications](https://owasp.org/www-project-top-10-for-large-language-model-applications/)
+- [Open Policy Agent](https://www.openpolicyagent.org/)


### PR DESCRIPTION
## 背景

车端 LLM Agent 落地时面临**多层**安全风险：

1. 身份与权限滥用（无 scope 的工具调用、委托链穿透）
2. 输入污染（Prompt Injection、PII、密钥泄露、危险命令）
3. 内容安全（SingGuard/NSFA 关注的"对 Agent 不安全"输出）
4. 工具副作用（`rm -rf`、`eval()`、网络外联）

业界对每一层都有单点产品（Protect AI LLM Guard、inclusionAI SingGuard / SingGuard-NSFA、Microsoft Entra Agent ID、SPIFFE/SPIRE、OWASP LLM Top 10），但缺少**面向车规 + C/C++ + 高通 NPU 部署**的整体可落地参考。本 PR 把它们拼成一条可评审的纵深防御架构，并给出参考 C SDK 骨架。

## 方案

采用**漏斗式五层防御**，越靠前越便宜、越确定性：

```
IAM (O(1))  →  规则 (<5ms)  →  Content Guard (~50ms)  →  NSFA (~45ms)  →  工具沙箱
```

每层 fail-closed，全部通过才放行。

### 关键设计决策

- **Agent IAM** 是入口闸门，而非事后审计。Scope 设计参考 [Microsoft Entra Agent ID](https://learn.microsoft.com/en-us/entra/identity-platform/agent-id) 的 blueprint 思路，落到 OAuth 2.0 + JWT 与 SPIFFE SVID 两条配方，前者适合云端协同，后者适合车端 mTLS。
- **Scope decay**：委托链每深入一层，权限自动收紧。`scope_depth ≥ 3` 仅保留 `read`，`depth ≥ 5` 直接拒绝。配合不变式 `child_scope ⊆ parent_scope`，防委托穿透。
- **规则匹配**走 Re2 → AC 自动机（编译期生成 `.rodata` 表）+ OPA Rego (Wasm)。车端无网络拉取，规则随固件烧写，避免 OTA 间隙的策略漂移。
- **Content Guard 与 NSFA** 双 Agent 串联：前者看输入/输出"对人"是否合规，后者看对 Agent 执行是否安全（NSFA = Not-Secure-For-Agents，对应 CIA 三元组）。
- **车规 C/C++ SDK** 落到 Qualcomm SA8155/8295/8775：mbedTLS（轻量，无 pthread 依赖）、SNPE → QNN 统一运行时、HTP→DSP→CPU 三级降级、AIC / SOME/IP / UDS 四种 API 提供方式覆盖舱内/跨域/同主机场景。

### §10 参考实现亮点（车端 C SDK 骨架）

- `agent_iam.h`：struct/enum/API 全集，纯 C11
- `scope_decay` 纯函数（确定性、可单测、可形式化验证）
- Guard 模型部署：QNN HTP 推理 + 自动回退 DSP/CPU
- 端到端调用时序图 + 8155 性能预算表

## 验证

- `npm run docs:build` 两次通过（56.85s / 53.91s）
- husky pre-commit 钩子：514 个 markdown 代码块审计无问题
- `docs:build` 输出 `.vitepress/dist/security/llm_agent_defense/layered_defense.html` 284K
- VitePress sidebar 集成到 "LLM Agent 防御" 分组

## 已知权衡 / 后续

- Shiki 未注册的语法（`pam/dts/rego/snort/haproxy/conf`）回退为 `txt`，可后续注入 langs
- §8 车规扩展（SOTIF、ISO 21434）目前为占位
- §6.2 集中式服务的多 Agent 协同调度未展开
- C SDK 仅含 IAM 部分；Guard 模型 SDK 与规则编译器后续 PR 跟进

## 文件

| 文件 | 状态 | 行数 |
| --- | --- | --- |
| `security/llm_agent_defense/layered_defense.md` | 新增 | 1081 |
| `.vitepress/config.mjs` | 修改 | +7 |

## 参考资料（节选）

- [Protect AI LLM Guard](https://github.com/protectai/llm-guard) — 已 archived 2026，仍可用作参考实现
- [inclusionAI/SingGuard](https://github.com/inclusionAI/SingGuard) — 多模态内容审核
- [inclusionAI/SingGuard-NSFA](https://github.com/inclusionAI/SingGuard-NSFA) — Agent 安全分类
- [Microsoft Entra Agent ID](https://learn.microsoft.com/en-us/entra/identity-platform/agent-id)
- [SPIFFE/SPIRE](https://spiffe.io/) — 工作负载身份
- [OWASP Top 10 for LLM Applications](https://owasp.org/www-project-top-10-for-large-language-model-applications/)
- [OPA / Rego](https://www.openpolicyagent.org/) — 策略即代码