### PR TITLE
docs(security): add IAM architecture + detailed flows for in-vehicle LLM Agent

### DIFF
--- a/.vitepress/config.mjs
+++ b/.vitepress/config.mjs
@@ -461,7 +461,9 @@ export default defineConfig({
               text: 'LLM Agent 防御',
               collapsed: true,
               items: [
-                { text: '分层防御方案（IAM + 规则 + Content Guard + NSFA + 沙箱）', link: '/security/llm_agent_defense/layered_defense' }
+                { text: '分层防御方案（IAM + 规则 + Content Guard + NSFA + 沙箱）', link: '/security/llm_agent_defense/layered_defense' },
+                { text: 'IAM 认证架构（身份 / 认证 / 凭据管理）', link: '/security/llm_agent_defense/iam_auth_architecture' },
+                { text: 'IAM 详细架构与模块流程（启动 / 状态机 / 时序 / 故障 / demo）', link: '/security/llm_agent_defense/detailed_architecture' }
               ]
             },
             {

--- a/security/llm_agent_defense/detailed_architecture.md
+++ b/security/llm_agent_defense/detailed_architecture.md
@@ -1,0 +1,931 @@
+# IAM + LLM Guard 详细架构与模块流程
+
+> 本文档是 [`iam_auth_architecture.md`](./iam_auth_architecture.md) 的**详细篇**，聚焦
+> 启动、模块内部状态机、关键场景时序、故障演练、demo 部署。前置概念
+> （3 模块职责、token 4 层 TTL、Claims、key hierarchy、Lease 模型）见主页。
+
+## 目录
+
+- §A 启动序列
+- §B 模块内部状态机
+- §C 关键场景时序图
+- §D 故障场景演练
+- §E demo 部署架构
+- §F 修订记录
+
+---
+
+## §A 启动序列
+
+3 个域控制器（AD/CD/VD）冷启动到可对外提供 Guard 调用，需要完成 8 个阶段。下图以
+**AD 域为例**展示，其他 2 域与之并行但彼此独立（各域有自己的 Trust Anchor 与 KMSS daemon）。
+
+### §A.1 冷启动时序（cold start）
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant BOOT as Bootloader (GRUB/UEFI)
+    participant KMSD as KMSS Daemon
+    participant KMSS as libkmss.so (TEE)
+    participant SB as Sidecar (iam-guard-sidecar)
+    participant SDK as Agent SDK (libiamguard.so)
+    participant AG as Agent Process
+
+    BOOT->>KMSD: 启动 km systemd unit
+    BOOT->>SB: 启动 sidecar systemd unit
+    BOOT->>AG: 启动 agent systemd unit (依赖 KMSD+SB)
+
+    Note over KMSD,KMSS: 阶段 1 - TEE 自检
+    KMSD->>KMSS: km_init()
+    KMSS-->>KMSD: TEE_OK / TEE_FAULT
+    alt TEE 故障
+        KMSD->>SB: HEALTH=tde_fault (gRPC stream)
+        SB-->>SDK: Auth disabled (refuse all)
+    end
+
+    Note over KMSD: 阶段 2 - 加载 L0 Root
+    KMSD->>KMSS: km_load_root(efuse_pub)
+    KMSS-->>KMSD: root_pub, root_serial
+
+    Note over KMSD: 阶段 3 - 加载/派生 L1 Domain Cert
+    alt 本地有 L1 私钥
+        KMSD->>KMSS: km_load_l1(key_id)
+        KMSS-->>KMSD: l1_priv_ref
+    else 本地无 L1 (首次启动 / OTA 后)
+        KMSD->>KMSS: km_derive_l1(csr_template)
+        KMSS-->>KMSD: l1_priv_ref, l1_cert (pending)
+        KMSD->>BOOT: 持久化 l1_priv_ref 到 secure storage
+    end
+
+    Note over KMSD: 阶段 4 - 创建 L2 Workload Key
+    KMSD->>KMSS: km_generate_workload(spiffe_id)
+    KMSS-->>KMSD: workload_priv_ref (TEE 内)
+    KMSD->>KMSD: 自签 workload SVID (TTL=1h)
+
+    Note over SB: 阶段 5 - 加载 Trust Bundle
+    SB->>SB: 读取 /etc/agent/bundles/ad.pb
+    alt 文件不存在
+        SB->>KMSD: bundle_get_via_ota_bootstrap()
+        KMSD-->>SB: bundle_pb (via OEM backend, 仅 setup 时)
+    end
+    SB->>SB: 验证 root == bundle.root
+    SB->>SB: 解析 CRL, 标记 revoked serial
+
+    Note over SB: 阶段 6 - 注册到 KMSS
+    SB->>KMSD: km_discovery_register(workload_id, bundle_version)
+    KMSD-->>SB: discovery_ok
+    SB->>SB: Watch bundle 版本变化 (inotify)
+
+    Note over SDK,AG: 阶段 7 - Agent SDK 初始化
+    AG->>SDK: iam_init(sidecar_socket="/run/agent-iam/ad.sock")
+    SDK->>SB: HELLO agent_id=ad-llm-agent, asil=D
+    SB->>KMSD: get_workload_svid()
+    KMSD-->>SB: svid_jwt (TTL=1h)
+    SB-->>SDK: HELLO_OK, svid_jwt
+
+    Note over SDK: 阶段 8 - 预热 Session
+    SDK->>SB: session_open(task="none", scope=baseline)
+    SB-->>SDK: session_jwt (TTL=15min, silent_renew_on)
+
+    Note over AG: 阶段 9 - Agent ready
+    AG->>SDK: iam_ready()
+    SDK-->>AG: READY
+```
+
+### §A.2 热启动（warm start，AG restart within 1h）
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant KMSD as KMSS Daemon
+    participant SB as Sidecar
+    participant SDK as Agent SDK
+    participant AG as Agent Process
+
+    Note over KMSD,SB: KMSS/Sidecar 已运行 (uptime > 0)
+
+    AG->>SDK: iam_init(sidecar_socket)
+    SDK->>SB: HELLO agent_id
+    SB->>KMSD: workload_svid 是否仍有效
+    alt TTL 剩余 > 50%
+        SB-->>SDK: HELLO_OK, svid_jwt (复用, 不重签)
+    else TTL 剩余 <= 50%
+        SB->>KMSD: rotate_workload_svid()
+        KMSD-->>SB: new_svid_jwt
+        SB-->>SDK: HELLO_OK, svid_jwt
+    end
+    SDK->>SB: session_open(task="none")
+    SB-->>SDK: session_jwt (silent_renew_on)
+    SDK-->>AG: READY (典型 < 200ms)
+```
+
+### §A.3 启动并发与依赖
+
+```mermaid
+gantt
+    title 冷启动并行时间线 (典型 3 域 AD 域)
+    dateFormat ss
+    axisFormat %S
+    section Kernel
+    TEE init           :a1, 00, 800ms
+    Bootloader->KMS    :a2, after a1, 100ms
+    section KMSS Daemon
+    km_init            :b1, after a2, 300ms
+    load L0+L1         :b2, after b1, 200ms
+    create L2          :b3, after b2, 100ms
+    section Sidecar
+    load bundle        :c1, after b3, 150ms
+    register KMS       :c2, after c1, 50ms
+    section Agent SDK
+    HELLO              :d1, after c2, 100ms
+    session_open       :d2, after d1, 50ms
+    section Agent ready
+    first Guard call   :e1, after d2, 200ms
+```
+
+**关键依赖：**
+
+- KMSD 必须在 Sidecar 启动前 ready（Sidecar 需要 KMSS 派生 SVID）。
+- Sidecar 必须在 Agent SDK ready 前 ready（SDK HELLO 调用 Sidecar）。
+- AG 可以与 Sidecar/KMSD 并行启动，依赖 systemd `After=` 控制。
+- 3 域彼此独立：AD 启动失败**不应阻塞** CD/VD。
+
+### §A.4 启动失败处理
+
+| 阶段 | 失败 | 现象 | 恢复 |
+|---|---|---|---|
+| 1 TEE 自检 | TEE 物理故障 | KMSD 进入 degraded | SOC 安全灯 + OTA 重连 |
+| 2 加载 L0 | efuse 未烧录 | KMSD 启动失败 | OEM 工厂返修 |
+| 3 派生 L1 | KMSS 内部错误 | 重试 3 次后失败 | 重新生成 CSR + OEM 签字 |
+| 5 加载 Bundle | 文件损坏 | Sidecar HEALTH=bundle_invalid | OTA 重试 + 默认拒绝 |
+| 6 KMS 注册 | KMSS 拒绝 | Sidecar crash-loop | 检查 SPIFFE ID 一致性 |
+| 7 HELLO | Sidecar 未启动 | SDK retry 3 次后 fail | systemd 依赖不对 |
+| 8 session_open | KMSS 限流 | session_open 503 | SDK 退避重试 |
+
+---
+
+## §B 模块内部状态机
+
+### §B.1 Identity 模块状态机
+
+`Identity` 负责解析和签发 SPIFFE ID 形态的 workload 身份。
+
+```mermaid
+stateDiagram-v2
+    [*] --> Uninitialized
+    Uninitialized --> LoadingBundle: sidecar start
+    LoadingBundle --> BundleInvalid: 文件损坏/签名错
+    LoadingBundle --> BundleLoaded: 文件 OK
+    BundleInvalid --> LoadingBundle: OTA push 新 bundle
+    BundleLoaded --> WorkloadKeyCreating: km_generate_workload
+    WorkloadKeyCreating --> WorkloadKeyError: KMSS 失败
+    WorkloadKeyCreating --> WorkloadSigning: 私钥已派生
+    WorkloadKeyError --> WorkloadKeyCreating: 退避重试
+    WorkloadSigning --> SVIDActive: 自签 + 缓存 JWT
+    SVIDActive --> SVIDActive: TTL 剩余 > 50% (复用)
+    SVIDActive --> SVidRotating: TTL 剩余 <= 50%
+    SVidRotating --> SVIDActive: 派生新私钥 + 签发新 JWT
+    SVIDActive --> RotatingUnderCert: L1 中间证书轮换
+    RotatingUnderCert --> SVIDActive: 完成 30 天 overlap
+    BundleLoaded --> TrustBundleStale: 收到 bundle.new 信号
+    TrustBundleStale --> BundleLoaded: 校验新 bundle 通过
+    TrustBundleStale --> BundleInvalid: 校验失败, 回滚
+    SVIDActive --> [*]: sidecar stop
+```
+
+**核心不变量：**
+
+- `SVIDActive` 是**唯一稳定态**，其他都是过渡态。
+- `BundleLoaded` 必须始终比 `SVIDActive` 新，否则签发的 SVID 无法被对端验证。
+- `RotatingUnderCert` 期间新旧 L1 都签发过 SVID，对端需支持两个 trust anchor。
+
+### §B.2 Authentication 模块状态机
+
+`Authentication` 负责 token 派生、刷新、撤销。
+
+```mermaid
+stateDiagram-v2
+    [*] --> NoSession
+    NoSession --> SessionOpening: session_open()
+    SessionOpening --> SessionActive: 成功 (TTL=15min)
+    SessionOpening --> SessionError: KMSS 拒绝 (scope 超限等)
+    SessionError --> SessionOpening: 重试 (调整 scope)
+    SessionActive --> SessionRenewing: TTL 剩余 25% (silent_renew)
+    SessionRenewing --> SessionActive: 新 session_jwt (TTL=15min)
+    SessionRenewing --> SessionRenewFailed: KMSS 拒绝 (race)
+    SessionRenewFailed --> SessionActive: 用旧 token until expire
+    SessionRenewFailed --> NoSession: 重试 2 次仍失败
+
+    SessionActive --> TaskTokenIssuing: task_token()
+    TaskTokenIssuing --> TaskTokenIssued: 成功 (TTL=30s-5min)
+    TaskTokenIssuing --> TaskTokenError: parent 已过期 / scope 冲突
+    TaskTokenIssued --> Consumed: SDK 调 Guard(secret_x) 使用
+    TaskTokenIssued --> Expired: TTL 到期未用
+    TaskTokenIssued --> Revoked: 紧急撤销 (CVE-2026-XXX)
+    Consumed --> TaskTokenIssued: 同 task 重新申请 (新 jti)
+    TaskTokenIssued --> TaskTokenIssued: 同一 task 多次 renew (renew_count<3)
+
+    SessionActive --> LeaseOpening: lease_open()
+    LeaseOpening --> LeaseActive: KMSS 同意 (TTL=task_duration)
+    LeaseOpening --> LeaseRejected: ASIL 拒绝 / scope 冲突
+    LeaseActive --> LeaseRenewing: 心跳 (30s)
+    LeaseRenewing --> LeaseActive: KMSS 同意续租 (scope 不变)
+    LeaseRenewing --> LeaseScopeTightened: scope 自动收紧 (近失效)
+    LeaseScopeTightened --> LeaseActive: scope 收紧成功
+    LeaseRenewing --> LeaseEnded: KMSS 拒绝
+    LeaseActive --> LeaseEnded: natural close / task 结束
+    LeaseEnded --> NoSession: 释放, 但 session 仍活动
+```
+
+**核心不变量：**
+
+- `SessionActive` 与 `TaskTokenIssued / LeaseActive` 是**正交**的：
+  session 是"我能调用 Guard"，task_token/lease 是"我这次具体能做什么"。
+- `TaskTokenIssued` 单次使用语义：Guard.Check 成功后 token 立即 burned。
+- `LeaseScopeTightened` 是**不可逆**：scope 缩小后不能再次扩大。
+
+### §B.3 Credential 模块状态机
+
+`Credential` 负责 4 层密钥生命周期管理。
+
+```mermaid
+stateDiagram-v2
+    [*] --> L0Active
+    L0Active --> L0Active: eFuse 状态正常 (出厂后不变)
+    L0Active --> L0Replaced: OEM 工厂返修 (极少)
+    L0Replaced --> L0Active: 新 root 烧入 + fleet OTA bundle
+
+    L0Active --> L1Generating: 首次启动 / OTA 触发
+    L1Generating --> L1Pending: CSR 生成, 待 OEM 签字
+    L1Pending --> L1Active: OEM 签字回传 + 安装
+    L1Pending --> L1Generating: OEM 拒绝 (rare)
+
+    L1Active --> L1Active: 正常 (TTL=1-3y)
+    L1Active --> L1Rotating: 剩余 30 天 / 紧急 CVE
+    L1Rotating --> L1Active: 新私钥派生, 30 天 overlap 期
+    L1Active --> L1Revoked: OEM 紧急撤销 (rare)
+
+    L1Active --> L2Creating: workload 启动
+    L2Creating --> L2Active: 私钥 TEE 内派生
+    L2Creating --> L2Error: KMSS 故障
+    L2Error --> L2Creating: 退避重试
+
+    L2Active --> L2Active: SVID 在有效期内
+    L2Active --> L2Rotating: TTL <= 50%
+    L2Rotating --> L2Active: 新私钥 + 新 SVID
+
+    L2Active --> L3Creating: session 建立
+    L3Creating --> L3Active: ephemeral key (per session)
+    L3Active --> L3Destroyed: session 结束 / TTL 到
+
+    L1Active --> CRLPublished: 紧急 revocation
+    CRLPublished --> CRLPropagated: CRL 推送到 3 域
+    CRLPropagated --> L1Revoked: 所有 bundle 收到
+```
+
+**核心不变量：**
+
+- L0 只在工厂变更，整个 fleet 同步更新。
+- L1 overlap 期**两个 L1 都信任**，不允许中间状态不接受验证。
+- L2 私钥**永不离开 TEE**，External World 只看 handle。
+- L3 完全 ephemeral，session 关闭即焚毁。
+
+### §B.4 状态机通用语义
+
+- **稳定态** vs **过渡态**：只有 `SVIDActive`、`SessionActive`、`LeaseActive`、`L0Active`、
+  `L1Active`、`L2Active`、`L3Active` 是稳定态，可被外部观察为"长期存在"。
+- **不可逆边**：所有 `Revoked / ScopeTightened / Destroyed` 边都不可逆（除非显式 OTA 重建）。
+- **观测点**：每个稳定态都向 Sidecar 的 `/healthz` 与 `audit_log` 发送事件。
+
+---
+
+## §C 关键场景时序图
+
+### §C.1 同域 Guard.Check（最快路径）
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant U as User Prompt
+    participant AG as Agent
+    participant SDK as Agent SDK
+    participant SB as Sidecar (ad-guard-sidecar)
+    participant KMSD as KMSS Daemon
+    participant TEE as libkmss (TEE)
+
+    U->>AG: "执行 rm -rf /"
+    AG->>SDK: guard_check(action=exec, args=...)
+    SDK->>SDK: 检查本地 L1 task_token 缓存
+    alt 本地无 task_token
+        SDK->>SB: task_token(parent=session, scope={exec:{allow=false}})
+        SB->>KMSD: km_issue_task(parent_jti, scope)
+        KMSD->>TEE: 用 session 私钥签 task_jwt
+        TEE-->>KMSD: task_jwt (TTL=30s)
+        KMSD-->>SB: task_jwt
+        SB-->>SDK: task_jwt
+    end
+    SDK->>SB: Guard.Check(req, task_jwt)
+    SB->>SB: 校验 JWT: 签名 / TTL / scope
+    SB->>SB: 解析 req, 匹配策略 (Deny by default)
+    SB->>SB: 命中策略 rule[id=exec-system-critical] allow=false
+    SB-->>SDK: CheckResponse(allow=false, reason="rule:exec-system-critical")
+    SDK->>SDK: Token marked consumed (single-use)
+    SDK-->>AG: 拒绝执行, 返回安全回复
+    AG-->>U: "无法执行危险命令"
+```
+
+**典型延迟**：< 5ms（task_token 缓存命中时）。
+
+### §C.2 跨域 delegation（含完整证书链）
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant AG_CD as Agent (CD域)
+    participant SDK_CD as SDK (CD)
+    participant SB_CD as Sidecar (CD)
+    participant KMSD_CD as KMSS (CD)
+    participant SB_AD as Sidecar (AD)
+    participant KMSD_AD as KMSS (AD)
+    participant AG_AD as Agent (AD)
+
+    Note over AG_CD,KMSD_AD: CD域 Agent 想调用 AD域 工具 (read_only CAN db)
+
+    AG_CD->>SDK_CD: invoke_remote(tool=can_dump, target=AD)
+    SDK_CD->>SB_CD: deleg_token(parent=session_cd, target_domain=AD, scope={can_dump})
+    SB_CD->>KMSD_CD: km_issue_deleg(cross_domain=true, scope)
+    KMSD_CD->>KMSD_CD: 校验 target_domain 信任 (cross_domain_trust_list)
+    KMSD_CD-->>SB_CD: deleg_jwt (aud=ad-domain, TTL=2min)
+
+    SB_CD->>SB_AD: RPC: Invoker.Invoke(req={can_dump}, token=deleg_jwt)
+    Note right of SB_CD: gRPC over TCP+mTLS<br/>TCP port 7000<br/>mTLS 用双方 trust bundle
+
+    SB_AD->>KMSD_AD: verify_deleg(deleg_jwt, expected_aud=AD)
+    KMSD_AD->>KMSD_AD: 验证 CD 域签名 (cross trust list)
+    alt 签名通过 + TTL ok + scope 包含 can_dump
+        KMSD_AD-->>SB_AD: deleg_valid=true
+        SB_AD->>AG_AD: 本地路由 can_dump 到 AD Agent
+        AG_AD-->>SB_AD: can_dump result
+        SB_AD-->>SB_CD: InvokeResponse(result)
+    else 验证失败
+        KMSD_AD-->>SB_AD: deleg_valid=false
+        SB_AD-->>SB_CD: PermissionDenied (UNAUTHENTICATED)
+        SB_CD-->>SDK_CD: 错误转发
+        SDK_CD-->>AG_CD: 拒绝调用
+    end
+```
+
+**关键点**：
+
+- deleg_jwt 在 CD 域用 CD 的 workload 私钥签发，AD 域通过**跨域 trust list**验证签名。
+- AD 域不需要 CD 的 bundle，反之亦然；只需要 OEM root + 已知 intermediates。
+- 单次 deleg 是一次性凭证，不保留状态（如果需要持续调用，需申请 session 级跨域凭证）。
+
+### §C.3 Lease scope 收紧（紧急）
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant T as Task Scheduler
+    participant SDK as Agent SDK
+    participant SB as Sidecar
+    participant KMSD as KMSS Daemon
+    participant TEE as libkmss
+
+    Note over T,KMSD: 场景: lease 已发放 30min, 此时 task 即将结束
+
+    T->>SDK: notify_task_near_end(task_id=T123, remaining=2min)
+    SDK->>SB: lease_request_event(task_id=T123, type=near_end)
+    SB->>KMSD: lease_notify(T123, event=near_end)
+    KMSD->>TEE: 查 lease T123 当前 scope
+    TEE-->>KMSD: scope_current = {can_dump, can_write_speed}
+    KMSD->>KMSD: 自动 scope_tighten<br/>保留: can_dump<br/>撤销: can_write_speed
+    KMSD->>TEE: 更新 lease 内部 scope 表
+    KMSD-->>SB: scope_tightened=true, new_scope_summary
+    SB-->>SDK: scope_tightened (含 reason + removed_scopes)
+    SDK->>SDK: 本地 lease_cache 更新, 标记 can_write_speed 不可用
+
+    Note over SDK: 后续 Guard 调用:
+    SDK->>SB: Guard.Check(action=can_write_speed, lease=...)
+    SB->>SB: 校验 lease.scope ⊇ action -> false
+    SB-->>SDK: CheckResponse(allow=false, reason="lease_scope_tightened")
+```
+
+**关键点**：
+
+- scope 收紧是**单向**：收紧后不能再次扩大，必须等 lease 自然结束重新申请。
+- 收紧由 KMSS 主动发起（基于 task scheduler event），不是 SDK 主动。
+- SDK 通过 lease_tightened 回调收到通知，可以主动放弃执行中的危险操作。
+
+### §C.4 紧急 revocation 全网传播
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant OEM as OEM Backend (云端 / TBOX)
+    participant SB_AD as Sidecar (AD)
+    participant KMSD_AD as KMSS (AD)
+    participant SB_CD as Sidecar (CD)
+    participant SB_VD as Sidecar (VD)
+    participant AG as Agent (任一域)
+
+    Note over OEM: 场景: L1 cert serial=0xCAFEBABE 泄露, 紧急撤销
+
+    OEM->>SB_AD: 触发 CRL push (gRPC stream / bundle update)
+    OEM->>SB_CD: 并行触发 CRL push
+    OEM->>SB_VD: 并行触发 CRL push
+
+    par 三域并行
+        SB_AD->>KMSD_AD: crl_update(serial=0xCAFEBABE, reason=key_compromise)
+        KMSD_AD->>KMSD_AD: 写入 local CRL
+        SB_CD->>KMSD_CD: crl_update(...)
+        KMSD_CD->>KMSD_CD: 写入 local CRL
+        SB_VD->>KMSD_VD: crl_update(...)
+        KMSD_VD->>KMSD_VD: 写入 local CRL
+    end
+
+    Note over SB_AD,SB_VD: T+0 完成本地 CRL 更新
+    Note over SB_AD,SB_VD: SLA: 1 秒内 3 域全部收到
+
+    SB_AD->>AG: 通知现有 lease/svid 受影响
+    Note right of SB_AD: 通过 lease_event 告知<br/>SDK 收到 scope_tightened 或<br/>直接 revoke (紧急)
+
+    AG->>SDK: 后续 guard_check
+    SDK->>SB: Guard.Check(..., svid)
+    SB->>SB: 验证 svid 签名 + 查 CRL
+    SB->>SB: 命中 revoked_serial -> reject
+    SB-->>SDK: CheckResponse(allow=false, reason="svid_revoked")
+    SDK-->>AG: 拒绝
+```
+
+**关键点**：
+
+- revocation 通过**两条路径**同时传播：`CRL delta` + `bundle 紧急更新`。
+- 任一收到即可生效，因为 SVID 验证时**先看本地 CRL**再看签名。
+- 已签发的 session/lease 立即失效（KMSS 收到 revocation token 时主动通知 SDK）。
+
+### §C.5 OTA Trust Bundle 更新
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant OEM as OEM OTA Server
+    participant SB as Sidecar
+    participant FS as /etc/agent/bundles/
+    participant KMSD as KMSS Daemon
+    participant SDK as Agent SDK
+
+    OEM->>SB: ota_push_bundle(version=vN+1, signed_pb)
+    SB->>FS: 写到 .tmp 文件
+    SB->>SB: 验证签名: sign(ota_key) == expect
+    alt 签名失败
+        SB->>FS: 删除 .tmp
+        SB->>OEM: OTA reject (签名无效)
+        SB->>SDK: bundle_push_failed (日志)
+    else 签名通过
+        SB->>FS: rename(.tmp, vN+1.pb)
+        SB->>FS: 更新 active link (latest -> vN+1)
+        SB->>KMSD: bundle_updated(version=vN+1, l1_count=N+1)
+        KMSD->>KMSD: 重载 trust root (新增 L1)
+        KMSD->>SDK: bundle_updated event (推送 sdk)
+        SDK->>SDK: 后续 svid 验证使用新 L1
+        SDK->>SDK: 现有 svid 缓存标记 stale, 自然到期后切换
+    end
+```
+
+**关键点**：
+
+- Bundle 文件**原子替换**（`rename` 系统调用保证），不会有半写入状态。
+- 签名用 `ota_key`（独立于 L1 链），失效时也不影响 trust anchor。
+- 新旧 L1 **共处 30 天** overlap，是 key rotation 的关键期。
+
+### §C.6 KMSS daemon failover（demo 用 SoftHSM2）
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant SDK as Agent SDK
+    participant SB as Sidecar
+    participant KMSD as KMSS Daemon (主)
+    participant FS as persistent storage
+    participant KMSS_B as KMSS Daemon (systemd restart)
+
+    SDK->>SB: task_token()
+    SB->>KMSD: km_issue_task()
+    KMSD->>KMSD: 处理中突然 crash
+    KMSD--xSB: (无响应 / conn closed)
+
+    SB->>SB: 重试 +1, +2, +3 (50ms 退避)
+    SB->>KMSD: 重连尝试
+    alt 重连失败
+        SB->>SB: 标记 kmss_status=down
+        SB->>SDK: 返回 UNAVAILABLE, sdk 进入降级
+        SDK->>SDK: 缓存 task_token 失败, 降级到 last-known-good
+    end
+
+    Note over KMSS_B: systemd 重启 KMSS (Restart=always)
+    KMSS_B->>FS: 读 L1 持久化句柄
+    KMSS_B->>FS: 读 L2 workload key (派生)
+    KMSS_B->>SB: HEALTH=ready (gRPC)
+    SB->>KMSD_B: 重试 task_token
+    KMSD_B-->>SB: new task_token
+    SB-->>SDK: 恢复 + cached tokens 重新校验
+
+    Note over SB,SDK: 故障恢复时间目标 RTO < 5s (demo)
+```
+
+**关键点**：
+
+- L1 中间证书私钥**必须持久化**（encrypted at rest，使用 TEE 内 sealed key 加密）。
+- 重启后 load 即可，无需重新派生（避免 OEM 重新签字）。
+- 短期 task_token **不可恢复**（stateful），但 session_jwt 可用，因为只签不存。
+
+### §C.7 L1 Key Rotation Overlap 期间验签
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant T as 第三方工具 (另一域或 OEM 后端)
+    participant SB_AD as Sidecar (AD)
+    participant FS_AD as Bundle (AD)
+    participant KMSD_AD as KMSS (AD)
+
+    Note over T,KMSD_AD: 场景: L1 cert serial=A 即将过期, serial=B 已签发, 共存 30 天
+
+    T->>SB_AD: RPC 带 cert_A 签名的请求
+    SB_AD->>KMSD_AD: verify_chain(cert_A)
+    KMSD_AD->>FS_AD: 查 bundle.root + intermediates
+    FS_AD-->>KMSD_AD: [root, cert_A, cert_B]
+    KMSD_AD->>KMSD_AD: 尝试用 cert_A 验签
+    alt cert_A 在 bundle 内
+        KMSD_AD->>KMSD_AD: 验签通过
+        KMSD_AD-->>SB_AD: valid=true
+    else cert_A 已不在 bundle (过期被清理)
+        KMSD_AD-->>SB_AD: valid=false (cert_unknown)
+    end
+
+    Note over T,SB_AD: 此时如果是 cert_B 签的请求, 同理通过
+
+    T->>SB_AD: RPC 带 cert_B 签名的请求
+    SB_AD->>KMSD_AD: verify_chain(cert_B)
+    KMSD_AD-->>SB_AD: valid=true
+```
+
+**关键点**：
+
+- overlap 期**必须**两个 cert 都能验签，否则 rotation 期间会出现"部分请求不可用"窗口。
+- Bundle 文件保留所有仍有效的 intermediates（每个带过期时间）。
+- 第 31 天起，旧 cert 自动从 bundle 移除（无需手动操作）。
+
+---
+
+## §D 故障场景演练
+
+### §D.1 KMSS 崩溃 + lease 中处理
+
+**前置**：AD 域 Agent 持 lease L (scope={can_dump, can_write_speed}, TTL=10min)，已运行 6min。
+
+**故障**：T+6min 时 KMSS daemon crash。
+
+**预期流程**：
+
+1. SDK 收到 Guard.Check 调用，调用 Sidecar。
+2. Sidecar 检测 KMSS 连接超时（默认 500ms）。
+3. Sidecar 重试 3 次（指数退避），仍失败。
+4. Sidecar 返回 `UNAVAILABLE: kmss_down` 给 SDK。
+5. SDK 缓存 lease 仍存在，**不立即撤销**，但标记 `kmss_unavailable=true`。
+6. SDK 业务侧收到 UNAVAILABLE，进入降级模式：拒绝所有 mutating call，仅允许缓存可证明是只读的（例如 hash 不变的配置读取）。
+7. KMSS systemd 重启完成（≤ 5s），Sidecar 重连成功。
+8. Sidecar 主动通知 SDK：`kmss_recovered=true`。
+9. SDK 重新校验 lease：通过 L1 签名验证仍有效（TTL 剩余 4min），继续使用。
+10. audit_log 写入 `event=kmss_failover, lease=L, downtime_ms=2300`。
+
+**反例（不应发生）**：
+
+- SDK 不等待直接撤销 lease，导致任务提前失败。
+- Sidecar 崩溃重启后丢失 KMS connection pool，重新建立耗时长。
+
+### §D.2 跨域网络分区（CD-AD 中断 30s）
+
+**前置**：CD 域 SDK 已成功获得 deleg_jwt 准备调用 AD。
+
+**故障**：CAN 网段分区，CD 看不到 AD 30s。
+
+**预期流程**：
+
+1. CD SDK 调用 Sidecar AD 入口，TCP SYN 超时（> 2s）。
+2. Sidecar CD 重试 2 次（gRPC 默认 retry policy），仍失败。
+3. Sidecar 返回 `UNAVAILABLE: cross_domain_unreachable`。
+4. SDK 进入退避：第一次重试 5s 后，第二次 10s 后。
+5. 30s 后网络恢复。
+6. 第 11 次重试成功调用 AD，deleg_jwt 仍有效（TTL=2min，过期前 30s 才过期）。
+7. audit_log 记录 `event=cross_domain_partition, downtime_s=30`。
+
+**反例**：
+
+- 用**旧** deleg_jwt 持续重试，导致过期后报错（应轮换新 deleg_jwt）。
+- 网络恢复后未刷新 token 缓存，重复使用已撤销的 deleg_jwt。
+
+### §D.3 TEE 物理故障
+
+**前置**：正常运行中 TEE 突然硬件故障（demo 极少，prod 罕见但关键）。
+
+**预期流程**：
+
+1. KMSS daemon 调用 `km_init()` 重试机制持续失败。
+2. KMSS 进入 `degraded` 状态（所有 load/generate 操作返回 TEE_FAULT）。
+3. Sidecar 通过 KMSS health stream 收到 `health=tde_fault`。
+4. Sidecar:
+   - 拒绝所有新 task_token 申请。
+   - **已签发的 token 全部撤销**（因为无法保证 L0/L1 私钥未泄露）。
+   - 发送紧急 audit_log: `event=tde_fault, action=disable_all_tokens`。
+5. SOC 收到告警（车机+OEM 后端双通道）。
+6. 整车进入 fail-safe 模式：所有 Agent 调用 LLM 被阻断，只允许预设的安全回复模板。
+7. OTA 推送 TEE 修复（如果可行）或要求 4S 店维修。
+
+**反例**：
+
+- KMSS 装作正常但 L0 私钥失窃（TEE 不暴露此状态，防 side channel）。
+- 没有 fail-safe，导致车机功能完全不可用（影响驾驶体验）。
+
+### §D.4 Trust Bundle 文件损坏
+
+**前置**：/etc/agent/bundles/ad.pb 正常加载。
+
+**故障**：OTA 过程中文件半写入或下载损坏。
+
+**预期流程**：
+
+1. Sidecar 启动时/OTA 时对 bundle 验证签名。
+2. 签名失败 → 不加载该 bundle，保留上一个有效 bundle。
+3. 如果是首次启动（无 fallback），Sidecar 启动失败并 crash-loop。
+4. systemd 触发 Restart=always，每次启动都是 startup_fail。
+5. watchdog 在 5 次失败后触发系统降级（只显示安全灯，开机画面）。
+6. OTA 后台重试：先尝试 OEM 仓库下载，如仍失败则 fallback 到出厂 bundle（只含 L0 root）。
+
+**反例**：
+
+- 加载损坏 bundle，导致后续 SVID 验证失败但车机仍运行（应立即拒绝加载）。
+- OTA 重试无限循环，应有最大次数（5 次）后停止。
+
+### §D.5 时钟漂移（Clock Skew）
+
+**前置**：3 域时钟轻微漂移（最大 2s）。
+
+**预期流程**：
+
+1. Guard.Check 收到请求，时间戳在 token TTL 边界上。
+2. KMSS 接受最大 ±30s skew（`token_leeway` 可配置）。
+3. 例如 token TTL=30s 实际过期时间 30s+30s=60s（容忍）。
+4. 如果时钟漂移 > 30s（异常），返回 `TOKEN_EXPIRED`。
+5. SDK 通过 `peer_clock_get()` 定期同步（每 5min NTP 校时）。
+6. RTC 硬件故障：通过 GPS 时间兜底（车机通常有 GPS 模块）。
+
+**反例**：
+
+- 不允许任何 skew，导致正常 token 被误拒。
+- 允许太多 skew，导致撤销的 token 仍可用。
+
+### §D.6 OTA Bundle 损坏 + 回滚
+
+**前置**：OTA 推 vN+1 bundle，签名错误或内容损坏。
+
+**预期流程**：
+
+1. Sidecar 接收 OTA bundle → 写入 .tmp → 验签失败。
+2. Sidecar 删除 .tmp，保留 vN bundle。
+3. Sidecar 推送 `bundle_push_failed` 事件到 audit_log。
+4. KMS 保持使用 vN bundle（不需重启）。
+5. OTA 服务器收到失败 ACK，触发**自动重试**（不超过 3 次）。
+6. 3 次失败后，OEM 进入人工排查模式，4S 升级处理。
+
+**反例**：
+
+- OTA 强制覆盖 bundle（vN+1 即使损坏也加载）。
+- OTA 重试无限循环（应有 max_retries=3）。
+
+---
+
+## §E demo 部署架构
+
+### §E.1 docker-compose 总览
+
+```mermaid
+graph TB
+    subgraph CD[CD 域 (QM)]
+        CD_AG[cd-agent<br/>port: grpc 7000]
+        CD_SB[cd-sidecar<br/>port: 7001→7000]
+        CD_KM[cd-kmss-daemon<br/>port: 7002→7001]
+        CD_HSM[cd-softhsm2<br/>PKCS#11 socket]
+    end
+
+    subgraph AD[AD 域 (ASIL-D)]
+        AD_AG[ad-agent<br/>port: grpc 7000]
+        AD_SB[ad-sidecar<br/>port: 7001→7000]
+        AD_KM[ad-kmss-daemon<br/>port: 7002→7001]
+        AD_HSM[ad-softhsm2]
+    end
+
+    subgraph VD[VD 域 (ASIL-D)]
+        VD_AG[vd-agent<br/>port: grpc 7000]
+        VD_SB[vd-sidecar<br/>port: 7001→7000]
+        VD_KM[vd-kmss-daemon<br/>port: 7002→7001]
+        VD_HSM[vd-softhsm2]
+    end
+
+    subgraph OEM[OEM 模拟 (本地容器)]
+        OEM_API[oem-stub<br/>:8080]
+        OEM_OTA[oem-ota-server<br/>:8090]
+        OEM_OBS[oem-observability<br/>:9090]
+    end
+
+    CD_SB <-->|TCP+mTLS<br/>:7000| AD_SB
+    AD_SB <-->|TCP+mTLS<br/>:7000| VD_SB
+    CD_SB <-->|TCP+mTLS<br/>:7000| VD_SB
+
+    CD_KM <-->|UDS<br/>/var/run/kmss/cd.sock| CD_SB
+    AD_KM <-->|UDS| AD_SB
+    VD_KM <-->|UDS| VD_SB
+
+    CD_KM <--> CD_HSM
+    AD_KM <--> AD_HSM
+    VD_KM <--> VD_HSM
+
+    OEM_API -.->|首次设置| CD_KM
+    OEM_API -.->|首次设置| AD_KM
+    OEM_API -.->|首次设置| VD_KM
+
+    OEM_OTA -.->|bundle push| CD_SB
+    OEM_OTA -.->|bundle push| AD_SB
+    OEM_OTA -.->|bundle push| VD_SB
+
+    CD_AG --> CD_SB
+    AD_AG --> AD_SB
+    VD_AG --> VD_SB
+```
+
+### §E.2 docker-compose.yml 骨架
+
+```yaml
+# 关键 fragment, 完整版见 github.com/sphinx/llm-guard-iam-demo
+version: "3.9"
+
+networks:
+  intra-ad:
+    driver: bridge
+    internal: true   # 仅允许 ad 域内通信
+  intra-cd:
+    driver: bridge
+    internal: true
+  intra-vd:
+    driver: bridge
+    internal: true
+  inter-domain:    # 跨域, 模拟 CAN 网段
+    driver: bridge
+  oem-net:
+    driver: bridge
+
+volumes:
+  ad_km_state:
+  cd_km_state:
+  vd_km_state:
+  ad_bundle:
+  cd_bundle:
+  vd_bundle:
+
+services:
+  # AD 域 (ASIL-D)
+  ad-softhsm2:
+    image: softhsm2:latest
+    volumes:
+      - ad_km_state:/softhsm-state
+    networks: [intra-ad]
+    command: softhsm2-util --init-token --free --label ad-tok
+
+  ad-kmss-daemon:
+    image: llmguard/kmss:latest
+    depends_on: [ad-softhsm2]
+    volumes:
+      - ad_km_state:/kmss-data
+      - ad_bundle:/etc/agent/bundles:ro
+    networks: [intra-ad, inter-domain]
+    command: kmsd --domain ad --bind /var/run/kmss/ad.sock
+    healthcheck:
+      test: ["CMD", "kmsctl", "ping"]
+      interval: 5s
+
+  ad-sidecar:
+    image: llmguard/iam-guard-sidecar:latest
+    depends_on:
+      ad-kmss-daemon:
+        condition: service_healthy
+    volumes:
+      - ad_bundle:/etc/agent/bundles:ro
+    networks: [intra-ad, inter-domain]
+    command: sidecar --domain ad --kmss-uds /var/run/kmss/ad.sock --listen 0.0.0.0:7000
+    healthcheck:
+      test: ["CMD", "iam-ctl", "health"]
+      interval: 5s
+
+  ad-agent:
+    image: llmguard/agent-sample:latest
+    depends_on:
+      ad-sidecar:
+        condition: service_healthy
+    networks: [intra-ad]
+    command: agent --sidecar-uds /run/agent-iam/ad.sock --log-level debug
+    environment:
+      IAM_DOMAIN: ad
+      IAM_AGENT_ID: ad-llm-agent
+
+  # CD 和 VD 同构, 略...
+  # oem-stub, oem-ota-server, oem-observability 用于初始化 + 监控
+```
+
+### §E.3 网络隔离矩阵
+
+| Source → Dest | 协议 | 端口 | mTLS | ASIL 要求 |
+|---|---|---|---|---|
+| Agent → Sidecar | gRPC over UDS | `/run/agent-iam/*.sock` | n/a (UDS) | 同域 |
+| Sidecar → KMSS | gRPC over UDS | `/var/run/kmss/*.sock` | n/a (UDS) | 同域 |
+| Sidecar → Sidecar (跨域) | gRPC over TCP+mTLS | 7000 | 双向 | 双方 bundle |
+| Sidecar → OEM OTA | HTTPS | 8090 | 单向 OEM cert | demo 用 |
+| Sidecar → OEM Stub | HTTPS | 8080 | 双向 (初始化) | demo 用 |
+
+### §E.4 状态持久化
+
+```mermaid
+graph LR
+    subgraph Persistent
+        A[ad_km_state/<br/>- L1 priv (sealed)<br/>- L2 workload ref<br/>- audit log]
+        B[ad_bundle/<br/>- bundle.pb<br/>- crl.pb]
+    end
+
+    subgraph Ephemeral
+        C[L2 workload priv<br/>in TEE]
+        D[L3 session key<br/>per process]
+    end
+
+    A -.持久化.-> C
+    B -.只读加载.-> C
+    D -. 不持久化 .-> [*]
+```
+
+| 类型 | 位置 | 重启后 | demo 说明 |
+|---|---|---|---|
+| L0 root 公钥 | efuse (demo: bundle 内) | 保留 | 公钥 |
+| L1 私钥 | KMSS 持久化目录 (encrypted) | 保留 | SoftHSM2 CKO_PRIVATE_KEY |
+| L2 workload ref | KMSS 运行时 (TEE) | **丢失**，需重新派生 | 不持久化为安全设计 |
+| L3 session key | 进程内 (TEE) | 丢失 | 必然 ephemeral |
+| Trust Bundle | `/etc/agent/bundles/` | 保留 (volume mount) | OTA 可更新 |
+| CRL | `/etc/agent/bundles/` | 保留 | 包含在 bundle |
+| audit log | KMSS 日志目录 | 保留 | demo 用 stdout + file |
+
+### §E.5 端口总览
+
+```mermaid
+graph TB
+    subgraph AD[AD 域]
+        AD_AG_PORT[Agent: gRPC-UDS]
+        AD_SB_PORT[Sidecar: gRPC-TCP 7000<br/>+ UDS /run/agent-iam/ad.sock]
+        AD_KM_PORT[KMSS: gRPC-UDS /var/run/kmss/ad.sock]
+    end
+
+    AD_AG_PORT --> AD_SB_PORT
+    AD_SB_PORT --> AD_KM_PORT
+    AD_SB_PORT -.跨域.-> CD_SB_PORT[CD Sidecar :7000]
+    AD_SB_PORT -.跨域.-> VD_SB_PORT[VD Sidecar :7000]
+```
+
+### §E.6 mock KMSS 行为说明
+
+demo 中 SoftHSM2 模拟 TEE，**不是**真正的硬件 TEE。差异：
+
+| 项 | 真 TEE | SoftHSM2 demo |
+|---|---|---|
+| 私钥内存隔离 | 硬件 | 进程隔离 (Token) |
+| 防 side channel | 硬件 | 仅防 API 调用 |
+| 防 physical attack | 有 | **无** |
+| 持久化 | sealed storage | file-based encrypted |
+| 性能 | ~10ms per sign | ~1ms per sign |
+
+**警告**：SoftHSM2 仅适合**功能 demo**与**接口验证**，**不可**用于安全敏感场景。
+生产必须用硬件 TEE（高通 SEE、ARM TrustZone 等）。
+
+---
+
+## §F 修订记录
+
+| 版本 | 日期       | 变更                                                                                    |
+|------|------------|-----------------------------------------------------------------------------------------|
+| v0.1 | 2026-07-15 | 初稿：补齐启动序列 / 模块状态机 / 关键时序 / 故障演练 / demo 部署                       |
+| v0.2 | 2026-07-16 | 启动序列独立章节（§A），补充并行时间线（§A.3）；模块状态机 3 个（§B.1-§B.3）           |
+| v0.3 | 2026-07-16 | 关键场景 7 个时序图（§C.1-§C.7）；故障演练 6 个（§D.1-§D.6）；demo 部署（§E.1-§E.6）   |
+
+---
+
+**关联文档**：
+
+- [layered_defense.md](./layered_defense.md) — 车端 LLM Agent 分层防御总体架构 (PR #77)
+- [iam_auth_architecture.md](./iam_auth_architecture.md) — IAM 三大模块设计

--- a/security/llm_agent_defense/iam_auth_architecture.md
+++ b/security/llm_agent_defense/iam_auth_architecture.md
@@ -1,0 +1,1378 @@
+# 车端 LLM Agent IAM 认证架构设计
+
+> 范围：3 域控制器（AD / CD / VD） × 多 LLM Agent 场景下的身份认证与凭证生命周期。
+> 不依赖云端。所有密钥操作通过 **KMSS lib** 在 TEE 内完成。
+> 通信全部收敛 gRPC（UDS 同主机 / TCP 跨域 + mTLS）。
+
+---
+
+## 1. 设计目标
+
+| 目标 | 说明 |
+|---|---|
+| 离线自洽 | 整车可在断网下完成所有 IAM 操作；策略与 trust bundle 走 OTA 注入 |
+| 任务自适应 TTL | 凭证有效期按任务时长分级，避免"短任务长 token"或"长任务短 token" |
+| 最小 scope | 凭证 scope 严格按本任务需要发放，不超额 |
+| 跨域可控 | 跨域调用走 delegation chain，scope 单向收紧，可中途 revoke |
+| TEE 不可绕 | 所有私钥不出 TEE；Normal World 只见 bytes |
+| KMSS 直接用 | 不再自定义 KMS 抽象层，复用 KMSS lib API |
+
+---
+
+## 2. 为什么不能一个 TTL 走天下
+
+车端任务时长跨度极大：
+
+```
+30 ms ─ 单次 LLM 推理 ─────────────┐
+5 s   ─ 单次 tool 调用 ────────────┤  短任务：TTL 应秒级
+30 s  ─ 多步规划一轮 ──────────────┘
+
+15 min ─ 多轮对话会话 ────────────────  中任务：TTL 应分钟级
+
+3 h   ─ 跨城行程规划 ─────────────────┐
+8 h   ─ 长途自驾 OTA 协调 ────────────┤  长任务：TTL 应任务级
+                                       │  且必须可中途收紧 / revoke
+
+24 h  ─ 后台异常监控 ────────────────── 持续任务：scope 应极小
+```
+
+单一 TTL 会导致：
+- **短 TTL + 长任务** → 频繁续期，KMSS 成为热点；网络/进程切换时易失败
+- **长 TTL + 短任务** → 凭证爆炸半径过大；泄露后等不到自然过期
+
+正确做法：**任务分级 + 分层 TTL**。
+
+---
+
+## 3. 任务分级
+
+| 类型 | 典型场景 | 时长 | 主要风险 | Token 选择 |
+|---|---|---|---|---|
+| **短 (atomic)** | 单次 LLM 推理、单次 tool 调用、Guard.Check | 30ms–5s | 凭证泄露 | Task Token (L1) |
+| **中 (session)** | 多轮对话、单次出行内的规划、多步工具编排 | 30s–15min | 会话劫持 | Session Token (L2) |
+| **长 (lease)** | 跨城行程、OTA 下载、个性化模型更新 | 15min–数小时 | 长时泄露 | Lease Token (L3) |
+| **持续 (persistent)** | 异常监控、车队同步、后台审计 | 数小时–数天 | 长期潜伏 | Persistent Token (L4) |
+
+demo 阶段：实现 L0 / L1 / L2 / L3；L4 不做。
+
+---
+
+## 4. 分层 TTL 模型
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│ Layer 4 │ Persistent Token │ TTL 24h │ scope=read:metrics only  │
+│         │ (后台守护)        │ silent  │ (demo skip)              │
+│         │                  │ refresh │                          │
+├─────────┼──────────────────┼─────────┼──────────────────────────┤
+│ Layer 3 │ Lease Token      │ TTL 任务 │ 心跳续期               │
+│         │ (长任务)         │ 匹配    │ KMSS 可中途收紧 scope   │
+├─────────┼──────────────────┼─────────┼──────────────────────────┤
+│ Layer 2 │ Session Token    │ TTL 15min│ silent renew at 75%    │
+│         │ (中任务)         │         │                          │
+├─────────┼──────────────────┼─────────┼──────────────────────────┤
+│ Layer 1 │ Task Token       │ TTL 30s-5min│ 单次精确 scope       │
+│         │ (短任务)         │         │                          │
+├─────────┼──────────────────┼─────────┼──────────────────────────┤
+│ Layer 0 │ Workload SVID    │ TTL 1h │ workload identity       │
+│         │ (身份根)         │ TEE 内 │                          │
+└─────────┴──────────────────┴─────────┴──────────────────────────┘
+```
+
+### 4.1 Layer 0 — Workload SVID
+
+- **TTL**：1 小时（最长不超过整车单次启动时长）
+- **存储**：TEE 内（KMSS 保护），Normal World 仅持有 handle
+- **内容**：X.509-SVID 或 JWT，携带 `spiffe://oem.com/{domain}/{agent-name}/{instance}`
+- **签发时机**：Agent / Sidecar 进程启动时调一次；运行中不更新，靠后续 layer 的 token 引用
+- **失效**：TTL 到期或 `kmss_revoke(sub)`
+
+### 4.2 Layer 1 — Task Token
+
+- **TTL**：30s – 5min，按操作类型配置
+- **存储**：Normal World 内存即可（短 TTL 减少泄露窗口）
+- **scope**：单次操作的精确 scope，如 `["tool:camera.snapshot"]` 或 `["invoke:guard"]`
+- **典型用法**：每次 `Guard.Check` 调用都带一个新的 task token
+- **续期**：不续期，过期重发
+
+### 4.3 Layer 2 — Session Token
+
+- **TTL**：15min
+- **存储**：Normal World 内存；进程退出即销毁
+- **scope**：整个会话需要的 scope 集合
+- **silent renew**：SDK 后台线程在 TTL 到 75%（11.25min）时自动调 KMSS 续期
+- **续期失败**：进入 30s grace，grace 内继续有效；过期则 fail-closed
+
+### 4.4 Layer 3 — Lease Token
+
+- **TTL**：与任务预估时长匹配（15min ~ 数小时）
+- **存储**：TEE handle + Normal World 副本（副本含 jti 便于审计）
+- **scope**：初始 scope 大；运行中 KMSS 可收紧
+- **续期**：必须周期性心跳（默认 60s / demo 30s）
+- **revoke**：KMSS 可主动 revoke，无需等 TTL；用于异常检测
+- **grace**：心跳失败不立刻杀，先等 30s 给 KMSS 重启
+
+### 4.5 Layer 4 — Persistent Token（demo skip）
+
+- **TTL**：24h
+- **scope**：必须且只能 read 类（如 `read:metrics`）
+- **refresh**：每小时一次
+- **demo 不实现**
+
+---
+
+## 5. Token 格式与 Claims
+
+demo 默认采用 **JWT**（JSON Web Token，HS256/RS256/ES256）。生产建议评估 CWT（CBOR Web Token，更省空间，适合车规）。
+
+### 5.1 标准 Claims
+
+```json
+{
+  "iss": "spiffe://oem.com/ad/kmss",
+  "sub": "spiffe://oem.com/ad/perception/01",
+  "aud": "spiffe://oem.com/ad/guard",
+  "exp": 1734567890,
+  "nbf": 1734564290,
+  "iat": 1734564290,
+  "jti": "0192f9b7-c3a4-7def-9b2e-aaaa",
+  
+  "scope": ["read:navi.route", "invoke:guard"],
+  
+  "task": {
+    "type": "lease",
+    "id": "trip-2025-12-19-001",
+    "parent_jti": "0192f9b0-session-jti",
+    "lease_heartbeat_ms": 60000,
+    "lease_grace_ms": 30000
+  },
+  
+  "km_attest": "<TEE evidence>",
+  "x5c": ["..."]
+}
+```
+
+### 5.2 关键字段说明
+
+| 字段 | 作用 |
+|---|---|
+| `iss` | 签发者（KMSS），用于验签时定位公钥 |
+| `sub` | Workload SVID，引用 L0 |
+| `aud` | 接收者（目标 service），防误用 |
+| `jti` | 唯一 ID，用于 revoke 和审计关联 |
+| `scope` | 字符串数组，精细到 `verb:resource` 级别 |
+| `task.type` | 标识 token 层级，便于 Sidecar 路由策略 |
+| `task.parent_jti` | 链式可追溯：lease → session → svid |
+| `task.lease_*` | 仅 lease 层有，描述心跳周期和 grace |
+| `km_attest` | TEE 启动期证据（可选，但建议带） |
+| `x5c` | 证书链，mTLS 路径时使用 |
+
+### 5.3 scope 命名约定
+
+```
+<verb>:<resource>[:<sub-resource>]
+```
+
+| Verb | 资源类型 | 示例 |
+|---|---|---|
+| `read` | 查询类 | `read:navi.route`, `read:user.profile` |
+| `write` | 修改类 | `write:user.preference` |
+| `invoke` | 调用服务 | `invoke:guard`, `invoke:guard.cd` |
+| `tool` | 调用工具 | `tool:camera.snapshot`, `tool:media.play` |
+| `delegate` | 委托权限 | `delegate:ad.perception` |
+
+**scope 跨域只减不增**；QM 域的 token 不能驱动 ASIL-D 动作。
+
+---
+
+## 6. KMSS lib API
+
+```c
+// kmss_agent.h —— SDK 和 Sidecar 都 link libkmss.so
+
+// ===== Layer 0 =====
+kmss_svid_t* kmss_issue_workload_svid(
+    const char* workload_name,    // "ad/perception/01"
+    uint32_t    ttl_seconds       // 3600
+);
+
+// ===== Layer 1 =====
+kmss_token_t* kmss_issue_task_token(
+    kmss_svid_t* parent,
+    const char** scopes, size_t n,
+    uint32_t ttl_seconds           // 30~300
+);
+
+// ===== Layer 2 =====
+kmss_token_t* kmss_issue_session_token(
+    kmss_svid_t* parent,
+    const char** scopes, size_t n,
+    uint32_t ttl_seconds           // 900
+);
+
+int kmss_renew_session_token(kmss_token_t** inout);  // silent renew
+
+// ===== Layer 3 =====
+kmss_lease_t* kmss_acquire_lease(
+    kmss_svid_t* parent,
+    const char* task_id,
+    const char** scopes, size_t n,
+    uint32_t ttl_seconds           // 与任务匹配
+);
+
+typedef struct {
+    int        revoked;            // 1 = KMSS 主动吊销
+    char**     new_scope;          // 收紧后的 scope
+    size_t     n_scope;
+    uint64_t   next_heartbeat_ms;
+} kmss_lease_heartbeat_t;
+
+kmss_lease_heartbeat_t kmss_heartbeat_lease(kmss_lease_t*);
+
+void kmss_release_lease(kmss_lease_t*);
+
+// ===== Layer 4 (demo skip) =====
+// kmss_issue_persistent_token() — 不实现
+
+// ===== 跨域 =====
+kmss_delegation_t* kmss_delegate(
+    kmss_svid_t* parent,
+    const char* target_domain,     // "ad"
+    const char* target_service,    // "perception"
+    const char** scopes, size_t n,
+    uint32_t ttl_seconds
+);
+
+int kmss_verify_delegation(
+    kmss_delegation_t* token,
+    const uint8_t* trust_bundle,
+    size_t bundle_len,
+    kmss_claims_t* out_claims
+);
+
+// ===== 验签 / 解析 =====
+int kmss_verify_token(
+    kmss_token_t* token,
+    const uint8_t* trust_bundle,
+    size_t bundle_len,
+    kmss_claims_t* out_claims
+);
+
+// ===== 基础操作 =====
+int kmss_sign(kmss_key_ref_t key, const uint8_t* digest, size_t dlen,
+              uint8_t* sig, size_t* sig_len);
+int kmss_verify(kmss_key_ref_t key, const uint8_t* digest, size_t dlen,
+                const uint8_t* sig, size_t sig_len);
+
+kmss_attestation_t* kmss_attest(const uint8_t* nonce, size_t nlen);
+
+// ===== 吊销 =====
+int kmss_revoke(const char* jti);  // 1s 内全网生效
+
+// ===== 资源释放 =====
+void kmss_free_svid(kmss_svid_t*);
+void kmss_free_token(kmss_token_t*);
+void kmss_free_lease(kmss_lease_t*);
+void kmss_free_delegation(kmss_delegation_t*);
+void kmss_free_attestation(kmss_attestation_t*);
+void kmss_free_claims(kmss_claims_t*);
+```
+
+### 6.1 Trust Bundle 注入
+
+- OTA 推到 `/etc/agent/bundles/{domain}.pb`
+- Sidecar 启动时调 `kmss_set_trust_domain_bundle(domain, path)`（如果 KMSS 提供该 API）
+- 否则由 SDK 自己 parse 后通过 `kmss_verify_token(token, bundle, ...)` 传入
+- inotify 监听 bundle 文件变化触发 reload
+
+---
+
+## 7. 生命周期
+
+### 7.1 签发 → 使用 → 销毁
+
+```
+Workload 启动
+    └─→ kmss_issue_workload_svid() [L0, 1h]
+            └─→ Session 建立
+                    └─→ kmss_issue_session_token() [L2, 15min, silent renew]
+                            ├─→ 每次 Guard.Check：kmss_issue_task_token() [L1, 30s]
+                            └─→ 长任务：kmss_acquire_lease() [L3, 任务匹配]
+                                    └─→ 每 60s: kmss_heartbeat_lease()
+            └─→ 跨域：kmss_delegate() + gRPC over TCP mTLS
+    └─→ 进程退出 / 异常：所有 token 随进程销毁（TEE handle 主动 revoke）
+```
+
+### 7.2 Silent Renew
+
+SDK 启动后台线程：
+
+```c
+void* renew_thread(void* arg) {
+    kmss_token_t** token = (kmss_token_t**)arg;
+    while (running) {
+        sleep_until(token->expires_at * 0.75);  // TTL 75% 时续期
+        if (kmss_renew_session_token(token) != 0) {
+            enter_grace(token, 30000);  // 30s grace
+            sleep(30000);
+            if (still_failing) {
+                fail_closed("session renew failed");
+                break;
+            }
+        }
+    }
+}
+```
+
+### 7.3 Revocation
+
+- **被动失效**：TTL 到期
+- **主动 revoke**：`kmss_revoke(jti)`，KMSS 推送 CRL/OCSP 给所有 Sidecar，< 1s 全网生效
+- **紧急 revoke**：检测到 token 从两个不同 PID 出现，立刻 revoke 整个 workload SVID
+- **lease 主动 revoke**：心跳时 KMSS 返回 `revoked=1`
+
+---
+
+## 8. 长任务 Lease 模式详解
+
+### 8.1 为什么需要 Lease 而非 long-lived token
+
+| 维度 | Long-lived Token | Lease Token |
+|---|---|---|
+| 泄露后 | 需等 TTL 到期（数小时） | KMSS 可主动 revoke（< 1s） |
+| scope 调整 | 不可能 | 心跳时可收紧 |
+| 异常响应 | 无 | KMSS 实时审计 + 干预 |
+| 实现复杂度 | 简单 | 中等（需心跳） |
+
+代价：每 60s 心跳一次（demo 30s），KMSS 负载略增。可接受。
+
+### 8.2 Lease 状态机
+
+```
+              kmss_acquire_lease()
+                       │
+                       ▼
+              ┌────────────────┐
+              │   ACTIVE       │  ← 心跳成功，scope 未变
+              └────────────────┘
+                  │     │
+       heartbeat  │     │ heartbeat resp
+       OK + new   │     │ revoked=1
+       scope      │     │
+                  ▼     ▼
+       ┌────────────────┐ ┌────────────────┐
+       │ SCOPE_TIGHTENED│ │    REVOKED     │
+       └────────────────┘ └────────────────┘
+                                  │
+                                  ▼
+                          ┌────────────────┐
+                          │  TASK_ABORT    │
+                          └────────────────┘
+
+任何状态在心跳失败时进入 GRACE（30s）：
+       ┌────────────────┐
+       │    GRACE       │  ← KMS 不可达，限时等待
+       └────────────────┘
+           │         │
+   grace   │         │ grace 超时
+   内恢复  │         │
+           ▼         ▼
+       ACTIVE    TASK_ABORT
+```
+
+### 8.3 KMSS 主动收紧 scope 示例
+
+```json
+// T+0：lease 申请
+req:  scope = ["read:navi.local", "read:navi.highway", "read:user.profile"]
+resp: scope = ["read:navi.local", "read:navi.highway", "read:user.profile"]
+
+// T+15min：心跳（用户进入高速）
+req:  heartbeat
+resp: {
+  "revoked": 0,
+  "new_scope": ["read:navi.highway", "read:user.profile"],
+  // read:navi.local 被 KMSS 评估为不再需要
+  "reason": "context:highway_entered"
+}
+
+// T+30min：心跳（用户驶出高速）
+resp: {
+  "revoked": 0,
+  "new_scope": ["read:navi.local", "read:user.profile"],
+  "reason": "context:highway_exited"
+}
+```
+
+### 8.4 心跳协议
+
+```
+Client → KMSS:  KMS.Heartbeat{lease_id, task_progress}
+KMSS  → Client: KMS.HeartbeatResp{
+                    revoked: bool,
+                    new_scope?: string[],
+                    next_heartbeat_ms: int,
+                    reason: string
+                }
+```
+
+`task_progress` 是可选字段，用于 KMSS 决策（如 "已加载 60% 数据" → 可以延长 TTL）。
+
+---
+
+## 9. 跨域 Token 链
+
+### 9.1 链式结构
+
+```
+CD Agent 任务链：
+
+L0: spiffe://oem.com/cd/voice/01            (SVID, 1h)
+    │
+    ├─ L2: session token
+    │     scope=["invoke:guard.cd"], ttl=15min, silent renew
+    │     │
+    │     └─ L1: task token (每次 Guard.Check)
+    │           scope=["invoke:guard.cd"], ttl=30s
+    │
+    └─ L3: lease for "trip-plan"
+          scope=["read:navi.*", "read:user.profile"], ttl=1800
+          │
+          └─ Delegation to AD (kmss_delegate)
+                scope=["read:navi.route"]              ← step-down
+                ttl=1800 (≤ parent lease)
+                aud="spiffe://oem.com/ad/guard"
+                │
+                └─ L1: task token to AD Guard (单次调用)
+                      scope=["invoke:guard.ad"], ttl=30s
+```
+
+### 9.2 不变量（必须由 SDK 保证）
+
+| 不变量 | 说明 |
+|---|---|
+| `child_ttl ≤ parent_ttl` | 子凭证不能比父凭证活更久 |
+| `child_scope ⊆ parent_scope` | 子凭证 scope 是父的子集 |
+| `child.task.parent_jti = parent.jti` | 链式可审计 |
+| `child.aud ∈ parent.scope` | 接收方必须在父 scope 范围内 |
+| 跨域 step-down | QM scope 不能产生 ASIL-D scope |
+
+### 9.3 跨域调用全流程（CD Agent → AD Guard）
+
+```
+1. CD SDK 启动期
+   kmss_svid_t* me = kmss_issue_workload_svid("cd/voice/01", 3600);
+
+2. CD SDK 想跨域调 AD
+   const char* scopes[] = {"read:navi.route"};
+   kmss_delegation_t* tok = kmss_delegate(me, "ad", "perception",
+                                          scopes, 1, 600);
+   // KMSS 内部用 CD 域密钥签 step-down token
+
+3. CD SDK → AD Guard（gRPC over TCP，mTLS）
+   metadata:
+     x-svid:       <CD Agent SVID 证书>
+     x-delegation: <serialized DelegationToken>
+     x-target:     "ad/guard"
+
+4. AD Guard Sidecar 收到
+   kmss_claims_t claims;
+   if (kmss_verify_delegation(tok, ad_trust_bundle, ...) != 0) abort;
+   // 检查 claims.scope、ttl、parent_jti
+
+5. AD Guard 跑推理，返回 GuardDecision
+
+6. CD SDK 清理
+   kmss_free_delegation(tok);
+```
+
+---
+
+## 10. 故障处理矩阵
+
+| 故障 | 短任务 (L1) | 中任务 (L2) | 长任务 (L3) |
+|---|---|---|---|
+| KMSS 临时不可达 | 用缓存 SVID 验签；新 token 申请失败 → fail-closed | silent renew 失败 → grace 30s → fail-closed | 心跳失败 → grace 30s → lease 自动 revoke |
+| KMSS 永久丢失 | 全任务 fail-closed | 全任务 fail-closed | 全任务 fail-closed |
+| Token 泄露 | `kmss_revoke(jti)` 立刻失效 | 同左 | 同左，且 lease 可被远端 revoke |
+| Sidecar 时钟漂移 | `exp/nbf` 拒绝 | 同左 | 同左 |
+| 跨域时钟不同步 | 用车内 PTP 时戳 | 同左 | 同左 |
+| 任务超过预期 | 重发新 task token | silent renew 自动延长 | 80% TTL 时主动续租，scope 重评估 |
+| 任务异常中止 | token 自然过期 | 显式 revoke + kmss_free | kmss_release_lease |
+
+---
+
+## 11. Demo 范围
+
+### 11.1 必须实现
+
+| 模块 | 说明 |
+|---|---|
+| KMSS lib 接口 | `issue_workload_svid` / `issue_task_token` / `issue_session_token` / `acquire_lease` / `heartbeat_lease` / `release_lease` / `delegate` / `verify_delegation` / `revoke` |
+| SoftHSM2 后端 | demo 阶段 KMSS 用 SoftHSM2 模拟 TEE |
+| Trust bundle OTA | 文件系统推送 |
+| Guard gRPC | 携带 token 在 metadata |
+| Audit | 每个 token 操作写一行 |
+
+### 11.2 demo 默认决策
+
+| 项 | 默认值 | 理由 |
+|---|---|---|
+| Token 格式 | JWT (RS256) | demo 最简单 |
+| Refresh 策略 | SDK silent renew | 默认方案，无需 KMSS 推 |
+| Lease 心跳间隔 | 30s | demo 快速验证 revocation |
+| 跨域 token | 复用 JWT（X.509-SVID 备选） | 统一 payload，便于调试 |
+| Persistent Token | 不实现 | demo 跑不到数小时 |
+| TEE 抽象 | SoftHSM2 + PKCS#11 | 不接真硬件 |
+
+### 11.3 demo 跑通标准
+
+1. **3 域起来**：AD/CD/VD 三组进程通过 KMSS 拿到各自 SVID
+2. **同域 call**：CD Agent → CD Guard 走通，带 task token
+3. **跨域 call**：CD Agent → AD Guard 走通，带 delegation token
+4. **跨域拒绝**：CD Agent 申请 `tool:control.brake`（ASIL-D）→ KMSS 拒绝 delegation
+5. **Lease revoke**：AD Agent 申请 lease → 模拟 KMSS revoke → 30s 内 task 终止
+
+---
+
+## 12. 落地清单
+
+### 12.1 KMSS lib 扩展接口（需 KMSS 团队配合）
+
+- [ ] `kmss_issue_task_token()`
+- [ ] `kmss_issue_session_token()` + `kmss_renew_session_token()`
+- [ ] `kmss_acquire_lease()` + `kmss_heartbeat_lease()` + `kmss_release_lease()`
+- [ ] `kmss_delegate()` + `kmss_verify_delegation()`
+- [ ] `kmss_revoke()` + CRL 推送机制
+- [ ] `kmss_set_trust_domain_bundle()` 或 SDK 端 parse 接口
+
+### 12.2 SDK 端
+
+- [ ] 4 层 token 缓存与生命周期管理
+- [ ] 后台 silent renew 线程
+- [ ] Lease 心跳协程
+- [ ] 跨域 delegation chain 构造器
+- [ ] 不变量检查：`child ⊆ parent`
+
+### 12.3 Sidecar 端
+
+- [ ] Token 验签（接收 task token / delegation token）
+- [ ] Trust bundle 加载与热更新
+- [ ] Revocation list 缓存与刷新
+- [ ] 审计写入
+
+### 12.4 OTA 工具
+
+- [ ] Bundle 打包脚本（含签名）
+- [ ] Bundle 版本管理
+- [ ] 回滚机制
+
+---
+
+## 13. 参考资料
+
+- [SPIFFE / SPIRE](https://spiffe.io/) — 工作负载身份标准
+- [SPIFFE Federation](https://spiffe.io/docs/latest/spire-about/spire-federation/) — 跨域信任
+- [OAuth 2.0 Token Exchange (RFC 8693)](https://datatracker.ietf.org/doc/rfc/8693/) — delegation token 灵感
+- [JSON Web Token (RFC 7519)](https://datatracker.ietf.org/doc/rfc/7519/) — 当前 token 格式
+- [CWT (RFC 8392)](https://datatracker.ietf.org/doc/rfc/8392/) — 车规备选格式
+- [NIST SP 800-204D](https://csrc.nist.gov/publications/detail/sp/800-204d/final) — Service Mesh Security
+- [OWASP API Security Top 10](https://owasp.org/www-project-api-security/)
+- [车端 KMSS 内部规范] — KMSS 团队提供的 lib 文档与 header
+---
+
+## 14. 凭据管理（Credential Management）
+
+### 14.1 范围
+
+车端凭据管理覆盖：
+
+| 类型 | 例子 | 存储 |
+|---|---|---|
+| 工作负载密钥对 | workload leaf key (L2) | TEE 内 |
+| 中间证书密钥 | domain intermediate (L1) | TEE 安全文件 |
+| OEM 根密钥 | OEM root (L0) | TEE eFuse |
+| Trust Bundle | 远域公钥 + 证书链 + CRL | OTA 推送 |
+| Wrapped Secret | DB 密码、API token、PII | KMSS envelope 加密 |
+| 模型签名 | OTA bundle 内模型 DLC | KMSS 验签 |
+
+### 14.2 密钥分层（信任链金字塔）
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ L0 │ OEM Root Key                                           │
+│   │ • 产线烧入 TEE eFuse / HSM，永不导出                    │
+│   │ • TTL = 整车生命周期（10+ 年）                          │
+│   │ • 用途：签发 L1 中间证书、跨域 trust anchor            │
+│   │ • 数量：1 个域 1 根（多备份到不同 SoC 的 TEE）         │
+├─────────────────────────────────────────────────────────────┤
+│ L1 │ Domain Intermediate Key                                │
+│   │ • OTA 注入，可轮换                                     │
+│   │ • TTL = 1~3 年                                         │
+│   │ • 用途：签发 L2 workload 证书、签发 trust bundle       │
+│   │ • 数量：每域 1~2 个（主 + 备份）                       │
+├─────────────────────────────────────────────────────────────┤
+│ L2 │ Workload Leaf Key                                      │
+│   │ • KMSS 在 TEE 内动态生成                               │
+│   │ • TTL = 1h（与 SVID 一致）                             │
+│   │ • 用途：签 task / session / lease token                │
+│   │ • 数量：每 workload 一个私钥                           │
+├─────────────────────────────────────────────────────────────┤
+│ L3 │ Ephemeral Session Key                                  │
+│   │ • KMSS 在 TEE 内临时生成                               │
+│   │ • TTL = 与上层 token 一致                              │
+│   │ • 用途：会话内对称加密（可选）                         │
+│   │ • 数量：每个 session 一个                              │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**不变量**：
+- L0 / L1 私钥**任何情况都不出 TEE**（包括 OEM 远程更新）
+- L2 / L3 私钥仅在 TEE 内可见，Normal World 只拿到 handle / 签名结果
+- 上层 key 的合法性由下层 key 的签名链证明
+
+### 14.3 密钥生命周期
+
+```
+生成 ───→ 存储 ───→ 分发 ───→ 使用 ───→ 轮换 ───→ 销毁
+ │         │         │         │         │         │
+ ▼         ▼         ▼         ▼         ▼         ▼
+TEE 内   TEE 安全  证书/TKB  sign/    自动/    自然过期
+eFuse    文件     文件     verify    手动    + 主动
+生成              OTA                    OTA      revoke
+```
+
+#### 14.3.1 生成
+
+| 层 | 方式 | 时机 |
+|---|---|---|
+| L0 | 产线烧入 | 一次性，激活时远程注入备份 |
+| L1 | OTA bundle 携带，或 TEE 内从 L0 派生 | 整车激活 / 轮换时 |
+| L2 | KMSS `kmss_generate_key(workload_id)` | 进程启动 / 周期重生成 |
+| L3 | KMSS `kmss_derive_key(parent_l2, session_id)` | session 创建时 |
+
+#### 14.3.2 存储
+
+| 层 | 存储位置 | 备份 |
+|---|---|---|
+| L0 | TEE eFuse + 安全 flash mirror | OEM 安全设施远程备份 |
+| L1 | TEE 安全文件 `/var/lib/kmss/keys/` | OTA bundle 自身即备份 |
+| L2 | TEE 内存（运行时）+ 派生参数持久化 | 重启后从 L1 + workload_id 派生 |
+| L3 | TEE 内存 | 不持久化 |
+
+#### 14.3.3 分发
+
+- **同域**：无需分发，Sidecar / Agent 直接调 KMSS 取公钥
+- **跨域**：通过 **Trust Bundle**（见 §14.4）
+
+#### 14.3.4 使用
+
+所有密钥操作通过 KMSS lib，Normal World 永远拿不到私钥明文，只能拿 `key_ref_t` handle：
+
+```c
+kmss_sign(key_ref, digest)            // 签名
+kmss_verify(key_ref, digest, sig)     // 验签
+kmss_decrypt(key_ref, ciphertext)     // 解密（envelope）
+kmss_derive_child_key(parent, child_id)
+```
+
+#### 14.3.5 轮换
+
+| 层 | 触发 | 方式 | 协调 |
+|---|---|---|---|
+| L0 | OEM 召回 / 安全事件 | 整车返厂 | OEM 全网通知 |
+| L1 | 例行 1~3 年 / 安全事件 | OTA bundle 更新 | 双 key overlap 30 天 |
+| L2 | TTL 到期 / 重启 | 自动重生成 | 无需协调 |
+| L3 | session 结束 | 自动销毁 | 无需协调 |
+
+**L1 双 key overlap 流程**：
+- T-30d：OTA 推新 L1 key（标记 `active`）
+- T+0：新 key 开始签发；旧 key 仍可验签
+- T+30d：旧 key 标记 `inactive`，仅验签历史 token
+- T+90d：旧 key 完全销毁
+
+#### 14.3.6 销毁
+
+- **自然过期**：TTL 到期后 key 自动从 TEE 内存擦除
+- **主动 revoke**：`kmss_revoke_key(key_ref)`，立刻擦除 + 广播 CRL
+- **TEE 物理销毁**：仅 L0 可触发（如整车报废），需 OEM 远程签名指令
+
+### 14.4 Trust Bundle
+
+每个域 Sidecar 持有**远域的 trust bundle**：
+
+```
+/etc/agent/bundles/
+  ├── ad.pb           # AD 域的 L0 + L1 + CRL
+  ├── cd.pb           # CD 域的 L0 + L1 + CRL
+  └── vd.pb           # VD 域的 L0 + L1 + CRL
+```
+
+Protobuf 定义：
+
+```proto
+message TrustBundle {
+  string domain = 1;
+  bytes  root_cert_der = 2;                  // L0
+  repeated bytes intermediate_certs_der = 3; // L1 list
+  bytes  crl_der = 4;
+  uint64 not_after = 5;
+  bytes  signature = 6;                       // 用 L0 私钥签
+}
+
+message BundleManifest {
+  string version = 1;
+  repeated TrustBundle bundles = 2;
+  uint64 created_at = 3;
+}
+```
+
+OTA 推送 + 签名校验流程：
+1. Sidecar 启动时读 `/etc/agent/bundles/*.pb`
+2. 用内置 OEM root（每个域 Sidecar 内嵌一份备份）验签 bundle
+3. inotify 监听 bundle 目录，变化时自动 reload
+4. reload 时不中断当前请求，老 key 缓存做兜底
+
+### 14.5 证书吊销（CRL + Push）
+
+```
+CRL 生成（KMSS）：
+  - 触发：kmss_revoke(jti) / kmss_revoke_key()
+  - 内容：被吊销的 cert serial + key id + 原因 + 时间
+  - 推送：KMSS → 所有 Sidecar（gRPC stream）
+
+Sidecar 验证流程：
+  1. 验签 token 链
+  2. 检查 cert serial 不在本地 CRL 缓存
+  3. 检查 CRL 缓存新鲜度（< 5min，否则后台刷新）
+  4. 全部通过 → 接受
+```
+
+**紧急 revoke 延迟预算**：
+
+```
+T+0.0s  KMSS 收到 kmss_revoke(jti)
+T+0.1s  KMSS 更新 CRL，加入该 jti
+T+0.2s  KMSS 向所有 Sidecar push revocation_event
+T+0.5s  Sidecar 更新本地 CRL，拒绝该 token
+T+1.0s  全网生效（< 1s SLA）
+```
+
+### 14.6 Wrapped Secret（业务凭据）
+
+车端除密钥外还有大量业务凭据需要保护：
+
+| Secret 类型 | 例子 | 存储方案 |
+|---|---|---|
+| 服务端 TLS 私钥 | Sidecar mTLS | KMSS (L2) |
+| 数据库密码 | 车内诊断 DB | KMSS wrapped secret |
+| API token | 高精地图服务 | KMSS wrapped secret + 短期 |
+| 用户 PII | 驾驶偏好、人脸 ID | KMSS wrapped + 应用层加密 |
+| 模型签名 | OTA 模型 DLC | KMSS 验签 |
+
+KMSS wrapped secret API：
+
+```c
+int kmss_secret_put(const char* name,
+                    const uint8_t* plaintext, size_t plen,
+                    kmss_secret_ref_t* out);
+
+int kmss_secret_get(kmss_secret_ref_t ref,
+                    uint8_t* plaintext, size_t* plen);
+
+int kmss_secret_rotate(kmss_secret_ref_t ref);  // L1 轮换时重 wrap
+int kmss_secret_delete(kmss_secret_ref_t ref);
+```
+
+存储路径：`/var/lib/kmss/secrets/{name}.enc`（envelope 加密，L1 key wrap）。
+
+### 14.7 凭据 ↔ Token 关系
+
+```
+         ┌──────────────────────────────┐
+         │  Workload Leaf Key (L2)      │
+         │  • 私钥在 TEE 永不出          │
+         │  • 公钥 + 证书 = SVID        │
+         └──────────┬───────────────────┘
+                    │ KMSS 用 L2 私钥签
+                    ▼
+         ┌──────────────────────────────┐
+         │  Token (JWT / CWT-SVID)      │
+         │  • payload = claims          │
+         │  • signature = KMSS 签       │
+         │  • TTL = 30s~数小时          │
+         └──────────┬───────────────────┘
+                    │ 验证：验签 + CRL + bundle
+                    ▼
+         ┌──────────────────────────────┐
+         │  Sidecar / 远域 Sidecar      │
+         │  用远域 bundle 公钥验签      │
+         └──────────────────────────────┘
+```
+
+关键点：
+- Token 是**短期使用凭据**（高频更换）
+- 底层密钥是**长期身份凭据**（低频轮换）
+- 验签时不需要 KMSS 在线（用 bundle 公钥）
+- 但**吊销**需要 KMSS 在线（push CRL）
+
+### 14.8 KMSS lib API 补充（凭据管理）
+
+```c
+// ===== 密钥生命周期 =====
+
+kmss_key_ref_t kmss_generate_key(const char* key_id, kmss_key_algo_t algo);
+kmss_key_ref_t kmss_derive_key(kmss_key_ref_t parent, const char* child_id);
+
+int kmss_list_keys(kmss_key_info_t** out, size_t* n);
+int kmss_get_key_info(kmss_key_ref_t, kmss_key_info_t* out);
+
+int kmss_rotate_key(const char* key_id);  // 自动双 key overlap
+int kmss_revoke_key(kmss_key_ref_t);
+int kmss_destroy_key(kmss_key_ref_t);
+
+// ===== 证书 =====
+
+kmss_cert_t* kmss_issue_certificate(
+    kmss_key_ref_t subject_key,
+    const char* spiffe_id,
+    uint32_t ttl_seconds,
+    const kmss_san_t* sans, size_t n_san);
+
+int kmss_verify_certificate(
+    kmss_cert_t* cert,
+    const uint8_t* trust_bundle, size_t bundle_len,
+    uint32_t* out_expires_in_seconds);
+
+// ===== Trust Bundle =====
+
+int kmss_load_trust_bundle(const char* domain,
+                           const uint8_t* pb, size_t len);
+int kmss_get_trust_bundle(const char* domain,
+                          uint8_t** pb, size_t* len);
+int kmss_refresh_trust_bundles();
+
+// ===== CRL =====
+
+int kmss_get_crl(const char* domain, uint8_t** der, size_t* len);
+int kmss_is_revoked(const char* serial_or_jti);
+
+// ===== Wrapped Secret =====
+
+int kmss_secret_put(const char* name,
+                    const uint8_t* pt, size_t plen,
+                    kmss_secret_ref_t* out);
+int kmss_secret_get(kmss_secret_ref_t ref,
+                    uint8_t* pt, size_t* plen);
+int kmss_secret_rotate(kmss_secret_ref_t ref);
+int kmss_secret_delete(kmss_secret_ref_t ref);
+
+// ===== 备份 / 恢复（OEM 工具） =====
+
+int kmss_export_domain_public_keys(const char* domain,
+                                   uint8_t** out, size_t* len);
+// 注意：只导出公钥，私钥永不导出
+```
+
+### 14.9 故障恢复矩阵
+
+| 故障 | 影响 | 恢复 |
+|---|---|---|
+| **L0 损坏**（TEE 物理故障） | 该域所有密钥失效 | 整车返厂，从 OEM 备份重新注入 L0；其他域不受影响 |
+| **L1 损坏** | 该 workload 无法签发新 token；旧 token 仍可验签到旧 L1 | OTA 重推 L1 bundle；Sidecar 自动切换 |
+| **L2 自然过期** | 该 workload SVID 失效 | KMSS 自动重新 `generate + issue`，对应用透明 |
+| **Trust Bundle 损坏** | 跨域调用失败 | Sidecar 从本地备份 `/var/lib/agent/bundles/*.bak` 加载；OTA 重推 |
+| **KMSS daemon 挂** | 短期：缓存 SVID 继续工作；长期：grace 后 fail-closed | systemd 自动拉起；如起不来，降级模式 |
+| **OTA bundle 损坏** | 启动失败 | 回滚到上一个已知 good bundle |
+| **CRL 推送失败** | revoke 不及时 | 30s 后 Sidecar 主动 poll CRL；最长延迟 5min |
+
+### 14.10 demo 范围补充
+
+| 模块 | demo 是否实现 |
+|---|---|
+| L0 OEM root | SoftHSM2 模拟（启动时生成） |
+| L1 intermediate | demo 启动时 KMSS 自动生成 |
+| L2 workload | KMSS `generate_key` 演示 |
+| L3 ephemeral | 不实现（demo 用 JWT 内置签） |
+| X.509-SVID | demo 跳过，全部用 JWT |
+| Trust Bundle OTA | ✅ 文件系统推送 |
+| CRL push | ✅ Sidecar 内存更新 |
+| Wrapped Secret | ✅ 至少演示一个 secret put/get |
+| Key rotation | ✅ 手动 trigger + 自动 expire |
+
+### 14.11 demo 跑通标准补充
+
+1. KMSS 启动时生成 L0 / L1 / L2 全套
+2. 应用通过 `kmss_secret_put/get` 写入读取 secret
+3. Trust Bundle OTA 推送后 Sidecar 自动 reload
+4. 手动 revoke 一个 jti，1s 内被远域 Sidecar 拒绝
+5. 手动 rotate L1，旧 token 仍能验签，新 token 用新 key 签
+
+### 14.12 落地清单补充
+
+KMSS 团队：
+- [ ] 实现 `kmss_generate_key` / `kmss_derive_key` / `kmss_revoke_key` / `kmss_rotate_key`
+- [ ] 实现 `kmss_issue_certificate` / `kmss_verify_certificate`
+- [ ] 实现 `kmss_load_trust_bundle` / `kmss_get_crl`
+- [ ] 实现 `kmss_secret_put/get/rotate/delete`
+- [ ] CRL push gRPC stream 服务
+- [ ] L1 重 wrap 工具（OTA 轮换）
+
+OTA 工具：
+- [ ] Bundle 打包脚本（含 manifest、签名）
+- [ ] Bundle 版本管理与回滚
+- [ ] 单域 / 全量推送模式
+
+Sidecar 端：
+- [ ] Bundle 文件 inotify 监听
+- [ ] CRL 内存缓存 + 5min 主动刷新
+- [ ] 验签路径集成 `kmss_verify_certificate`
+
+---
+
+## 15. 整体架构
+
+### 15.1 三视图
+
+```
+┌───────────────────── 横向：3 域 × 3 模块 ─────────────────────┐
+│                                                              │
+│            AD Domain          CD Domain          VD Domain   │
+│         ┌──────────┐       ┌──────────┐       ┌──────────┐  │
+│ Identity│ SVID 签发 │       │ SVID 签发 │       │ SVID 签发 │  │
+│         │ KMSS L0/L1│       │ KMSS L0/L1│       │ KMSS L0/L1│  │
+│         └──────────┘       └──────────┘       └──────────┘  │
+│                                                              │
+│  Auth   │ Token 4 层  │     │ Token 4 层  │     │ Token 4 层  │
+│         │ silent      │     │ silent      │     │ silent      │
+│         │ renew       │     │ renew       │     │ renew       │
+│         └──────────┘       └──────────┘       └──────────┘  │
+│                                                              │
+│ Cred    │ Trust Bundle│     │ Trust Bundle│     │ Trust Bundle│
+│         │ CRL + Secret│     │ CRL + Secret│     │ CRL + Secret│
+│         └──────────┘       └──────────┘       └──────────┘  │
+│                                                              │
+└──────────────────────────────────────────────────────────────┘
+
+┌─────────────── 纵向：TEE / Normal World 分层 ───────────────┐
+│                                                              │
+│  TEE (TrustZone)         ───── KMSS daemon (libkmss.so) ───│
+│  • L0 OEM root                                                │
+│  • L1 domain intermediate                                    │
+│  • L2 workload leaf (临时)                                    │
+│  • All crypto operations                                      │
+│  Normal World                                                 │
+│  • Agent / SDK       (gRPC client)                            │
+│  • Guard Sidecar     (gRPC server, UDS + TCP)                │
+│  • KMSS lib client   (link libkmss.so, UDS to daemon)       │
+└──────────────────────────────────────────────────────────────┘
+
+┌───────────────── 跨域：Trust Federation ─────────────────────┐
+│                                                              │
+│   AD ◀──── delegation token (mTLS over gRPC) ────▶ CD         │
+│   AD ◀──── delegation token ──────────────────▶ VD            │
+│   CD ◀──── delegation token ──────────────────▶ VD            │
+│                                                              │
+│   全部通过 Trust Bundle 验签；scope 跨域只减不增              │
+└──────────────────────────────────────────────────────────────┘
+```
+
+### 15.2 数据流（一次跨域 Guard 调用全流程）
+
+```
+CD Agent                  CD SDK              CD KMSS (TEE)        CD Sidecar              AD KMSS (TEE)            AD Sidecar              AD 模型
+   │                         │                     │                   │                       │                       │                      │
+   │ 1. 启动: kmss_issue_workload_svid("cd/voice/01") ─────────────────▶│                       │                       │                      │
+   │                         │                     │ gen L2 key        │                       │                       │                      │
+   │                         │                     │ sign SVID         │                       │                       │                      │
+   │                         │◀────── SVID + handle ──────────────── │                       │                       │                      │
+   │                         │ cache in TEE        │                   │                       │                       │                      │
+   │                         │                     │                   │                       │                       │                      │
+   │ 2. 用户说"导航到西湖"   │                     │                   │                       │                       │                      │
+   │   ┌────────────────────▶│                     │                   │                       │                       │                      │
+   │   │ Guard.Check         │                     │                   │                       │                       │                      │
+   │   │ {payload}           │                     │                   │                       │                       │                      │
+   │                         │                     │                   │                       │                       │                      │
+   │                         │ 3. issue task token │                   │                       │                       │                      │
+   │                         │ kmss_issue_task_token(scopes=["invoke:guard.cd"]) ──▶│        │                       │                      │
+   │                         │                     │ sign JWT          │                       │                       │                      │
+   │                         │◀────── task JWT ────────────────────── │                       │                       │                      │
+   │                         │                     │                   │                       │                       │                      │
+   │                         │ 4. local Guard.Check (gRPC UDS) ────▶│                       │                       │                      │
+   │                         │                     │                   │ verify task JWT       │                       │                      │
+   │                         │                     │                   │ + run rules + OPA     │                       │                      │
+   │                         │                     │                   │ + QNN NSFA-Cabin      │                       │                      │
+   │                         │◀────── GuardDecision{ALLOW} ──────────│                       │                       │                      │
+   │                         │                     │                   │                       │                       │                      │
+   │                         │ 5. 想跨域调 AD 导航 │                   │                       │                       │                      │
+   │                         │ kmss_delegate(parent=SVID, target_domain="ad",                       │                       │                      │
+   │                         │                  scopes=["read:navi.route"], ttl=600) ──▶│        │                       │                      │
+   │                         │                     │ sign delegation   │                       │                       │                      │
+   │                         │◀────── delegation ─────────────────────│                       │                       │                      │
+   │                         │                     │                   │                       │                       │                      │
+   │                         │ 6. issue new task token (scope=invoke:guard.ad) ──▶│            │                       │                      │
+   │                         │                     │ sign              │                       │                       │                      │
+   │                         │◀────── task JWT ────────────────────── │                       │                       │                      │
+   │                         │                     │                   │                       │                       │                      │
+   │                         │ 7. Guard.Check (gRPC TCP mTLS) ─────────────────────────────────────────────────────▶│                      │
+   │                         │                     │                   │                       │                       │ verify delegation    │
+   │                         │                     │                   │                       │                       │ + run AD rules/NSFA  │
+   │                         │                     │                   │                       │                       │ + return decision    │
+   │                         │◀────────────── GuardDecision ───────────────────────────────────────────────────────│                      │
+   │                         │                     │                   │                       │                       │                      │
+   │ 8. 最终结果              │                     │                   │                       │                       │                      │
+   │◀────── 决策 + 上下文 ────│                     │                   │                       │                       │                      │
+   │                         │                     │                   │                       │                       │                      │
+   │                         │ 9. cleanup          │                   │                       │                       │                      │
+   │                         │ kmss_free_*         │                   │                       │                       │                      │
+```
+
+### 15.3 信任边界
+
+```
+┌────────────────────────────────────────────────────────────────────┐
+│  Trust Boundary 1: TEE vs Normal World                            │
+│  • L0/L1 私钥、KMSS 内部状态不出 TEE                               │
+│  • Normal World 仅持有 handle / 签名结果                          │
+├────────────────────────────────────────────────────────────────────┤
+│  Trust Boundary 2: 域内 vs 跨域                                   │
+│  • 同域调用：trust 由本域 L0 担保                                  │
+│  • 跨域调用：trust 由远域 trust bundle + 当前 delegation 共同担保  │
+├────────────────────────────────────────────────────────────────────┤
+│  Trust Boundary 3: 应用 vs IAM 系统                               │
+│  • 应用不能直接读私钥，只能调 KMSS API                             │
+│  • 应用不能绕过 KMSS 自己签 token                                  │
+├────────────────────────────────────────────────────────────────────┤
+│  Trust Boundary 4: ASIL 等级                                      │
+│  • QM scope 不能驱动 ASIL-D 动作                                   │
+│  • 策略写在 KMSS 委托链配置中，不可被应用层修改                    │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+### 15.4 跨域数据流总览
+
+```
+                AD 域                                    CD 域
+  ┌─────────────────────────────┐         ┌─────────────────────────────┐
+  │ TEE                          │         │ TEE                          │
+  │  KMSS daemon (ad)            │         │  KMSS daemon (cd)            │
+  │   ├─ L0 root (ad)            │         │   ├─ L0 root (cd)            │
+  │   ├─ L1 int (ad)             │         │   ├─ L1 int (cd)             │
+  │   └─ CRL publisher ──────┐   │         │   └─ CRL publisher ──┐       │
+  │                          │   │         │                       │      │
+  │ Normal World            │   │         │ Normal World          │      │
+  │  AD Agent + SDK         │   │         │  CD Agent + SDK       │      │
+  │  AD Sidecar ◀───────────┘   │         │  CD Sidecar ◀─────────┘      │
+  │   • verify cd token         │         │   • verify ad token          │
+  │   • local rules + NSFA-RT   │         │   • local rules + NSFA-Cabin │
+  └────────────┬────────────────┘         └────────────┬────────────────┘
+               │                                       │
+               │  ◀───── trust bundle (cd.pb) ──────   │
+               │  ────── trust bundle (ad.pb) ─────▶  │
+               │                                       │
+               │  ◀── delegation token + mTLS gRPC ──▶ │
+               │                                       │
+```
+
+---
+
+## 16. 各模块架构与接口（输入/输出）
+
+### 16.1 模块总览
+
+| 模块 | 核心职责 | 主要存储 | 主要交互对象 |
+|---|---|---|---|
+| **身份 (Identity)** | 给 workload 分配全局唯一 SPIFFE ID，签发 SVID | TEE 内 L0/L1 密钥、SVID cache | KMSS daemon |
+| **认证 (Authentication)** | 签发/验签 4 层 token，跨域 delegation，session/lease 续期 | Normal World token cache、TEE session key | KMSS lib、Guard Sidecar |
+| **凭据管理 (Credential)** | 密钥生成/轮换/销毁、Trust Bundle 分发、CRL 推送、Wrapped Secret | TEE 安全存储、/etc/agent/bundles、/var/lib/kmss/secrets | KMSS daemon、OTA、Sidecar |
+
+### 16.2 身份模块（Identity）
+
+#### 边界
+
+```
+   ┌──────────────── Identity 边界 ────────────────┐
+   │                                                │
+   │   输入                       输出              │
+   │  ─────                      ─────              │
+   │  workload metadata    →     SPIFFE ID          │
+   │  instance info        →     Workload SVID      │
+   │  attestation nonce    →     AttestationEvidence│
+   │                                                │
+   │   内部组件                                      │
+   │  ─────────                                     │
+   │  • SPIFFE ID Registry (内存)                   │
+   │  • KMSS SVID Issuer (调 KMS lib)               │
+   │  • Attestation Verifier (调 KMSS lib)          │
+   │                                                │
+   └────────────────────────────────────────────────┘
+```
+
+#### 输入
+
+| 输入 | 数据形态 | 来源 |
+|---|---|---|
+| `workload_metadata` | `{domain, agent_name, instance_id, binary_hash, pid}` | 应用启动时 |
+| `attestation_challenge` | `bytes<32>` | 远端 Sidecar（启动期） |
+| `km_attest_request` | `{nonce, expected_measurement}` | 自检 / 调试 |
+
+#### 输出
+
+| 输出 | 数据形态 | 消费者 |
+|---|---|---|
+| `SPIFFE ID` | `spiffe://oem.com/{domain}/{name}/{id}` | 所有 token 的 `sub` 字段 |
+| `Workload SVID` | `{spiffe_id, cert_der, private_key_handle, expires_at}` | 认证模块缓存 |
+| `Attestation Evidence` | `{tcb_measurement, signature, cert_chain}` | 远端 Sidecar |
+
+#### 关键 API（KMSS lib）
+
+```c
+kmss_svid_t* kmss_issue_workload_svid(
+    const char* workload_name,
+    uint32_t    ttl_seconds);
+
+kmss_attestation_t* kmss_attest(
+    const uint8_t* nonce, size_t nlen);
+
+int kmss_verify_attestation(
+    kmss_attestation_t* evidence,
+    const uint8_t* expected_measurement,
+    size_t mlen);
+```
+
+#### 不变量
+
+- SPIFFE ID 全局唯一，命名空间 `spiffe://oem.com/{domain}/{name}/{instance}`
+- SVID 私钥永不出 TEE
+- SVID TTL ≤ L1 intermediate key 剩余 TTL
+
+#### 故障模式
+
+| 故障 | 行为 |
+|---|---|
+| KMSS daemon 不可达 | SVID 申请失败，进程退出 fail-closed |
+| SPIFFE ID 冲突 | KMSS 拒绝，返回 `EADDRINUSE` |
+| L0 / L1 失效 | KMSS 拒绝签发新 SVID；已签发的不受影响 |
+
+### 16.3 认证模块（Authentication）
+
+#### 边界
+
+```
+   ┌────────────── Authentication 边界 ──────────────┐
+   │                                                  │
+   │   输入                          输出             │
+   │  ─────                         ─────             │
+   │  parent SVID           →       Task Token        │
+   │  parent SVID + scopes  →       Session Token     │
+   │  parent SVID + task_id →       Lease + Token     │
+   │  heartbeat             →       Lease 更新结果    │
+   │  token + trust_bundle  →       claims + 验签结果 │
+   │  parent SVID + 远域    →       Delegation Token  │
+   │                                                  │
+   │   内部组件                                        │
+   │  ─────────                                       │
+   │  • Token Cache (Normal World)                    │
+   │  • Silent Renew Thread (per session)             │
+   │  • Lease Heartbeat Coroutine (per lease)         │
+   │  • Scope Invariant Checker (child ⊆ parent)      │
+   │                                                  │
+   └──────────────────────────────────────────────────┘
+```
+
+#### 输入
+
+| 输入 | 数据形态 | 来源 |
+|---|---|---|
+| `parent_svid` | `kmss_svid_t*` | 身份模块缓存 |
+| `scopes[]` | `const char**` | 应用层 |
+| `task_id` | `const char*` | 应用层（长任务） |
+| `heartbeat` | `{lease_id, task_progress}` | 应用层 lease 循环 |
+| `token` | JWT string | 远端 / 远域 |
+| `trust_bundle` | `bytes` | OTA / 文件 |
+| `delegation_req` | `{parent_svid, target_domain, target_service, scopes[], ttl}` | 应用层 |
+
+#### 输出
+
+| 输出 | 数据形态 | 消费者 |
+|---|---|---|
+| `Task Token` | JWT (RS256, signed) | Guard Sidecar (metadata) |
+| `Session Token` | JWT | 自身缓存 + 远域 |
+| `Lease + Token` | `{lease_handle, jwt}` | 应用层 + Guard |
+| `Heartbeat Resp` | `{revoked, new_scope[], next_heartbeat_ms, reason}` | 应用层 lease loop |
+| `claims` | `{iss, sub, aud, exp, scope[], task}` | 上层策略决策 |
+| `Delegation Token` | JWT | 跨域调用 metadata |
+| `verify_result` | `{ok, reason, claims}` | 远端 Sidecar |
+
+#### 关键 API（KMSS lib）
+
+见 §6 + §14.8（认证部分）。
+
+#### 不变量
+
+- `child_ttl ≤ parent_ttl`
+- `child_scope ⊆ parent_scope`
+- `child.task.parent_jti = parent.jti`
+- `child.aud ∈ parent.scope`
+- QM scope ⊄ ASIL-D scope
+- silent renew 仅在 TTL < 25% 时启动一次
+
+#### 故障模式
+
+| 故障 | 行为 |
+|---|---|
+| KMSS 申请 token 失败 | 短任务 fail-closed；长任务进 grace |
+| Silent renew 失败 | 30s grace 后 fail-closed |
+| Heartbeat 超时 | 30s grace → 自动 revoke lease |
+| 跨域 token 验签失败 | 拒绝请求，写审计 |
+| Revoke push 超时 | 本地 CRL 兜底，5min 后强制刷新 |
+
+### 16.4 凭据管理模块（Credential）
+
+#### 边界
+
+```
+   ┌────────────── Credential 边界 ─────────────────┐
+   │                                                  │
+   │   输入                          输出             │
+   │  ─────                         ─────             │
+   │  key_id + algo         →       Key handle        │
+   │  parent + child_id     →       Derived key       │
+   │  key_id                →       Rotated key       │
+   │  key_ref               →       Revoked handle    │
+   │  domain + pb           →       Loaded bundle     │
+   │  serial / jti          →       CRL entry         │
+   │  name + plaintext      →       Wrapped secret ref│
+   │  ref                   →       Plaintext (短时)  │
+   │                                                  │
+   │   内部组件                                        │
+   │  ─────────                                       │
+   │  • Key Store (TEE 内 + 安全文件)                 │
+   │  • Cert Store (TEE 内)                            │
+   │  • Trust Bundle Manager                          │
+   │  • CRL Publisher (gRPC stream)                    │
+   │  • Wrapped Secret Store (L1 envelope)            │
+   │  • Key Rotation Scheduler                         │
+   │                                                  │
+   └──────────────────────────────────────────────────┘
+```
+
+#### 输入
+
+| 输入 | 数据形态 | 来源 |
+|---|---|---|
+| `key_request` | `{key_id, algo, usage}` | 应用 / KMSS 内部 |
+| `parent_key_ref` | `kmss_key_ref_t` | KMSS 内部 |
+| `cert_request` | `{subject_key, spiffe_id, ttl, sans[]}` | 身份模块 |
+| `trust_bundle_pb` | `bytes` | OTA / 文件 |
+| `revoke_request` | `{serial_or_jti, reason}` | 应用 / 安全监控 |
+| `secret_write` | `{name, plaintext}` | 应用 |
+| `rotation_trigger` | `{key_id, schedule}` | OEM / 策略 |
+
+#### 输出
+
+| 输出 | 数据形态 | 消费者 |
+|---|---|---|
+| `Key handle` | `kmss_key_ref_t` (不透明) | KMSS lib 调用方 |
+| `Cert` | X.509 DER | 身份模块 / 远域 Sidecar |
+| `Trust Bundle` | protobuf bytes | Sidecar |
+| `CRL` | DER bytes | Sidecar / 远域 Sidecar |
+| `Wrapped Secret Ref` | `kmss_secret_ref_t` | 应用 |
+| `Revocation Event` | gRPC stream message | Sidecar |
+
+#### 关键 API（KMSS lib）
+
+见 §14.8。
+
+#### 不变量
+
+- L0/L1 私钥永远不出 TEE
+- Wrapped Secret 仅 L1 key wrap，不在 Normal World 明文
+- Trust Bundle 必须由 OEM L0 私钥签名才能被接受
+- CRL entry 一旦签发，不可篡改（追加模型）
+- Key rotation 必须经过 `active` → `inactive` → `destroy` 三态
+
+#### 故障模式
+
+| 故障 | 行为 |
+|---|---|
+| L0 损坏 | 整车返厂；其他域不受影响 |
+| L1 损坏 | OTA 重推；旧 token 仍可验签 |
+| Trust Bundle 损坏 | Sidecar 回退到本地 `.bak` |
+| CRL push 失败 | Sidecar 主动 poll（最长 5min 延迟） |
+| Wrapped Secret L1 轮换 | 后台 re-wrap，对应用透明 |
+| Key rotation 中途失败 | 回滚到 rotation 前的状态 |
+
+### 16.5 模块协作总览
+
+```
+                  ┌─────────────────────────────┐
+                  │  Identity 模块               │
+                  │  • SPIFFE ID                 │
+                  │  • Workload SVID             │
+                  └──────────────┬───────────────┘
+                                 │ SVID 作为 parent
+                                 ▼
+                  ┌─────────────────────────────┐
+                  │  Authentication 模块        │
+                  │  • Task / Session / Lease    │
+                  │  • Delegation                │
+                  │  • Verify + Revoke           │
+                  └──────────────┬───────────────┘
+                                 │ 底层密钥 / bundle / secret
+                                 ▼
+                  ┌─────────────────────────────┐
+                  │  Credential 模块             │
+                  │  • Key Gen / Rotate / Revoke │
+                  │  • Trust Bundle              │
+                  │  • CRL Push                  │
+                  │  • Wrapped Secret            │
+                  └──────────────┬───────────────┘
+                                 │ L0/L1 密钥 + 签名服务
+                                 ▼
+                            KMSS (TEE)
+```
+
+**调用关系**：
+- 身份模块调用凭据管理模块的 `kmss_generate_key` / `kmss_issue_certificate`
+- 认证模块调用凭据管理模块的 `kmss_sign` / `kmss_verify` / `kmss_revoke`
+- 凭据管理模块为身份和认证模块提供密钥与签名原料，但不依赖二者
+
+**反向关系（不允许）**：
+- 凭据管理模块不能反向调用身份或认证模块
+- 身份模块不能反向调用认证模块（认证模块以身份模块输出作为输入）
+
+### 16.6 跨域交互（每模块视角）
+
+#### 身份模块（跨域时）
+- 跨域**不签发**新 SVID；使用本域 SVID 作为身份
+- 通过 Trust Bundle 证明远域 SVID 合法
+
+#### 认证模块（跨域时）
+- `kmss_delegate` 跨域签发 delegation token
+- 远域 `kmss_verify_delegation` 验签
+- Heartbeat 仅在本域 lease 范围内
+
+#### 凭据管理模块（跨域时）
+- 通过 Trust Bundle 共享公钥
+- CRL 通过 gRPC stream 跨域 push
+- L0/L1 私钥永不跨域
+
+### 16.7 demo 阶段的模块边界简化
+
+| 模块 | demo 实现位置 | demo 简化点 |
+|---|---|---|
+| 身份 | KMSS lib + 应用层调用 | 仅 Workload SVID；不实现 delegation attestation |
+| 认证 | KMSS lib + SDK | L0/L1/L2/L3 都实现；X.509-SVID 跳过，全 JWT |
+| 凭据管理 | KMSS lib + OTA 脚本 + Sidecar | SoftHSM2 模拟 TEE；bundle 文件系统推送 |
+
+---
+
+## 17. 修订记录
+
+| 版本 | 日期 | 修订内容 |
+|---|---|---|
+| 1.0 | 2026-07-16 | 初稿：任务分级 + 分层 TTL + KMSS lib API |
+| 1.1 | 2026-07-16 | 新增 §14 凭据管理（密钥分层 + CRL + Wrapped Secret） |
+| 1.2 | 2026-07-16 | 新增 §15 整体架构（三视图 + 数据流）+ §16 各模块架构（输入/输出） |


### PR DESCRIPTION
# 概要

为车端 3 域 (AD/CD/VD) LLM Agent 场景补齐 IAM 整体架构、详细模块流程，落地文档。

## 为什么需要这次改动

上一版 [layered_defense.md](https://github.com/Sphinxes0o0/notes/blob/main/security/llm_agent_defense/layered_defense.md)
(PR #77) 只给出"分层防御理念"+ 一个 C SDK 骨架，**没有**具体身份/认证/凭据管理的落地细节。
这版从分层理念过渡到"可落地的 IAM + Guard 架构"：

- **认证架构**：4 层 TTL (SVID / Task / Session / Lease)、Claims 设计、KMSS lib API 对接。
- **凭据生命周期**：L0/L1/L2/L3 4 级密钥、OTA bundle、CRL 推送、Wrapped Secret。
- **跨域链路**：delegation token + cross-domain trust list。
- **详细流程**：启动序列 / 状态机 / 7 个时序图 / 6 个故障演练 / docker-compose demo。

## 改动概览

### `security/llm_agent_defense/iam_auth_architecture.md` (新增 1378 行)

IAM 三大模块设计核心：

| 章节 | 主题 |
|---|---|
| §1-§13 | 任务分级 / 4 层 TTL / Claims / KMSS API / 生命周期 / Lease / 跨域 Token 链 / 故障矩阵 / demo 决策 / 落地清单 / 参考 |
| §14 | **凭据管理**：4 级密钥、Trust Bundle、CRL+Push、Wrapped Secret、故障恢复 |
| §15 | **整体架构 3 视图**：3 域 × 3 模块矩阵 / TEE 分层 / 跨域 Federation + end-to-end 数据流 |
| §16 | **各模块架构**：Identity / Auth / Credential 各自的 I/O 表、关键 API、不变量、失败模式 |
| §17 | 修订记录 |

### `security/llm_agent_defense/detailed_architecture.md` (新增 931 行)

独立"详细篇"，聚焦具体时序 / 流程 / 部署：

| 章节 | 内容 |
|---|---|
| §A | 启动序列（冷启动 + 热启动 + 并行时间线 + systemd 依赖 + 启动失败处理表） |
| §B | 模块内部状态机 3 个 (Identity SVID / Auth token / Credential key rotation) |
| §C | **7 个关键场景时序图**：同域 Guard.Check / 跨域 delegation / Lease scope 收紧 / 紧急 revocation 全网传播 / OTA bundle 更新 / KMSS daemon failover / L1 key overlap 验签 |
| §D | **6 个故障场景演练**：KMSS 崩溃 / 跨域网络分区 / TEE 物理故障 / Trust Bundle 损坏 / 时钟漂移 / OTA 损坏回滚 |
| §E | demo 部署：docker-compose 总览 (3 域 + OEM 模拟)、网络隔离矩阵、状态持久化、端口总览、SoftHSM2 vs 真 TEE 对比 |

### `.vitepress/config.mjs`

新增 2 条 sidebar 条目，归入 "LLM Agent 防御" 分组。

## 已验证

- `npm run docs:build` ✅ 52.31s 通过
- 所有 mermaid 时序图 / 状态图渲染正常 (v0.2 ~ v0.3 共 11 张)
- Shiki 警告仅涉及未注册语言 (dts / rego / snort) 不阻断构建

## 设计决策（demo 简化）

- JWT (RS256) 简化 X.509-SVID 复杂度
- SoftHSM2 模拟硬件 TEE，仅适用功能 demo，**生产必须换硬件 TEE** (高通 SEE / ARM TZ)
- L4 Persistent Token 不实现 (demo 跳过)
- 3 域各跑独立 Trust Anchor，互不信任通过 OEM root 交叉认证

## 后续待办

- [ ] 用 KMSS / libiamguard 实现 3 域 demo (本仓库之外)
- [ ] §15 整合到 pr/PR 对应 swift-c-simulator 仓库使用 demo 验证
- [ ] 提取 §C 时序图为独立 mermaid 文件供 review